### PR TITLE
Update to 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+rebuild.sh
+build-dir/
+.flatpak-builder/

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -28,14 +28,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/aligned/aligned-0.4.2.crate",
-        "sha256": "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923",
-        "dest": "cargo/vendor/aligned-0.4.2"
+        "url": "https://static.crates.io/crates/aligned/aligned-0.4.3.crate",
+        "sha256": "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685",
+        "dest": "cargo/vendor/aligned-0.4.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923\", \"files\": {}}",
-        "dest": "cargo/vendor/aligned-0.4.2",
+        "contents": "{\"package\": \"ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685\", \"files\": {}}",
+        "dest": "cargo/vendor/aligned-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -457,6 +457,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/autotools/autotools-0.2.7.crate",
+        "sha256": "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf",
+        "dest": "cargo/vendor/autotools-0.2.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf\", \"files\": {}}",
+        "dest": "cargo/vendor/autotools-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/av-scenechange/av-scenechange-0.14.1.crate",
         "sha256": "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394",
         "dest": "cargo/vendor/av-scenechange-0.14.1"
@@ -517,6 +530,19 @@
         "type": "inline",
         "contents": "{\"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\", \"files\": {}}",
         "dest": "cargo/vendor/base64-0.22.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bindgen/bindgen-0.71.1.crate",
+        "sha256": "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3",
+        "dest": "cargo/vendor/bindgen-0.71.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3\", \"files\": {}}",
+        "dest": "cargo/vendor/bindgen-0.71.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -600,19 +626,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/block2/block2-0.5.1.crate",
-        "sha256": "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f",
-        "dest": "cargo/vendor/block2-0.5.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f\", \"files\": {}}",
-        "dest": "cargo/vendor/block2-0.5.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/block2/block2-0.6.2.crate",
         "sha256": "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5",
         "dest": "cargo/vendor/block2-0.6.2"
@@ -678,14 +691,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.19.0.crate",
-        "sha256": "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43",
-        "dest": "cargo/vendor/bumpalo-3.19.0"
+        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.19.1.crate",
+        "sha256": "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510",
+        "dest": "cargo/vendor/bumpalo-3.19.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43\", \"files\": {}}",
-        "dest": "cargo/vendor/bumpalo-3.19.0",
+        "contents": "{\"package\": \"5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510\", \"files\": {}}",
+        "dest": "cargo/vendor/bumpalo-3.19.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -769,14 +782,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/camino/camino-1.2.1.crate",
-        "sha256": "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609",
-        "dest": "cargo/vendor/camino-1.2.1"
+        "url": "https://static.crates.io/crates/camino/camino-1.2.2.crate",
+        "sha256": "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48",
+        "dest": "cargo/vendor/camino-1.2.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609\", \"files\": {}}",
-        "dest": "cargo/vendor/camino-1.2.1",
+        "contents": "{\"package\": \"e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48\", \"files\": {}}",
+        "dest": "cargo/vendor/camino-1.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -821,14 +834,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.2.48.crate",
-        "sha256": "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a",
-        "dest": "cargo/vendor/cc-1.2.48"
+        "url": "https://static.crates.io/crates/cc/cc-1.2.49.crate",
+        "sha256": "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215",
+        "dest": "cargo/vendor/cc-1.2.49"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.2.48",
+        "contents": "{\"package\": \"90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.2.49",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -842,6 +855,19 @@
         "type": "inline",
         "contents": "{\"package\": \"6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c\", \"files\": {}}",
         "dest": "cargo/vendor/cesu8-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cexpr/cexpr-0.6.0.crate",
+        "sha256": "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766",
+        "dest": "cargo/vendor/cexpr-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766\", \"files\": {}}",
+        "dest": "cargo/vendor/cexpr-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -912,6 +938,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clang-sys/clang-sys-1.8.1.crate",
+        "sha256": "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4",
+        "dest": "cargo/vendor/clang-sys-1.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4\", \"files\": {}}",
+        "dest": "cargo/vendor/clang-sys-1.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clap/clap-4.5.53.crate",
         "sha256": "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8",
         "dest": "cargo/vendor/clap-4.5.53"
@@ -972,6 +1011,19 @@
         "type": "inline",
         "contents": "{\"package\": \"bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4\", \"files\": {}}",
         "dest": "cargo/vendor/clipboard-win-5.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cmake/cmake-0.1.57.crate",
+        "sha256": "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d",
+        "dest": "cargo/vendor/cmake-0.1.57"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d\", \"files\": {}}",
+        "dest": "cargo/vendor/cmake-0.1.57",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1050,6 +1102,32 @@
         "type": "inline",
         "contents": "{\"package\": \"6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e\", \"files\": {}}",
         "dest": "cargo/vendor/convert_case-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/convert_case/convert_case-0.10.0.crate",
+        "sha256": "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9",
+        "dest": "cargo/vendor/convert_case-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9\", \"files\": {}}",
+        "dest": "cargo/vendor/convert_case-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cookie/cookie-0.16.2.crate",
+        "sha256": "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb",
+        "dest": "cargo/vendor/cookie-0.16.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb\", \"files\": {}}",
+        "dest": "cargo/vendor/cookie-0.16.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1302,6 +1380,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossterm/crossterm-0.29.0.crate",
+        "sha256": "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b",
+        "dest": "cargo/vendor/crossterm-0.29.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b\", \"files\": {}}",
+        "dest": "cargo/vendor/crossterm-0.29.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossterm_winapi/crossterm_winapi-0.9.1.crate",
+        "sha256": "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b",
+        "dest": "cargo/vendor/crossterm_winapi-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b\", \"files\": {}}",
+        "dest": "cargo/vendor/crossterm_winapi-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crunchy/crunchy-0.2.4.crate",
         "sha256": "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5",
         "dest": "cargo/vendor/crunchy-0.2.4"
@@ -1445,6 +1549,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_more/derive_more-2.1.0.crate",
+        "sha256": "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618",
+        "dest": "cargo/vendor/derive_more-2.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-2.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_more-impl/derive_more-impl-2.1.0.crate",
+        "sha256": "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b",
+        "dest": "cargo/vendor/derive_more-impl-2.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-impl-2.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/digest/digest-0.10.7.crate",
         "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
         "dest": "cargo/vendor/digest-0.10.7"
@@ -1549,27 +1679,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/dlopen2/dlopen2-0.8.1.crate",
-        "sha256": "8d65cde5fb0c42a3d5882d99807698b459f5928de035fa7f547c784fb7b34219",
-        "dest": "cargo/vendor/dlopen2-0.8.1"
+        "url": "https://static.crates.io/crates/dlopen2/dlopen2-0.8.2.crate",
+        "sha256": "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4",
+        "dest": "cargo/vendor/dlopen2-0.8.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8d65cde5fb0c42a3d5882d99807698b459f5928de035fa7f547c784fb7b34219\", \"files\": {}}",
-        "dest": "cargo/vendor/dlopen2-0.8.1",
+        "contents": "{\"package\": \"5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4\", \"files\": {}}",
+        "dest": "cargo/vendor/dlopen2-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/dlopen2_derive/dlopen2_derive-0.4.2.crate",
-        "sha256": "95f4a04e1bfbfa4835a6073177aafb95ead4de0722dbb339195fdc7e0a09599b",
-        "dest": "cargo/vendor/dlopen2_derive-0.4.2"
+        "url": "https://static.crates.io/crates/dlopen2_derive/dlopen2_derive-0.4.3.crate",
+        "sha256": "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f",
+        "dest": "cargo/vendor/dlopen2_derive-0.4.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"95f4a04e1bfbfa4835a6073177aafb95ead4de0722dbb339195fdc7e0a09599b\", \"files\": {}}",
-        "dest": "cargo/vendor/dlopen2_derive-0.4.2",
+        "contents": "{\"package\": \"0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f\", \"files\": {}}",
+        "dest": "cargo/vendor/dlopen2_derive-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1583,6 +1713,19 @@
         "type": "inline",
         "contents": "{\"package\": \"aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562\", \"files\": {}}",
         "dest": "cargo/vendor/doctest-file-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/document-features/document-features-0.2.12.crate",
+        "sha256": "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61",
+        "dest": "cargo/vendor/document-features-0.2.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61\", \"files\": {}}",
+        "dest": "cargo/vendor/document-features-0.2.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1913,6 +2056,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fantoccini/fantoccini-0.21.5.crate",
+        "sha256": "e3a6a7a9a454c24453f9807c7f12b37e31ae43f3eb41888ae1f79a9a3e3be3f5",
+        "dest": "cargo/vendor/fantoccini-0.21.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3a6a7a9a454c24453f9807c7f12b37e31ae43f3eb41888ae1f79a9a3e3be3f5\", \"files\": {}}",
+        "dest": "cargo/vendor/fantoccini-0.21.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fastrand/fastrand-2.3.0.crate",
         "sha256": "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be",
         "dest": "cargo/vendor/fastrand-2.3.0"
@@ -2116,6 +2272,19 @@
         "type": "inline",
         "contents": "{\"package\": \"cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf\", \"files\": {}}",
         "dest": "cargo/vendor/form_urlencoded-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fs_extra/fs_extra-1.3.0.crate",
+        "sha256": "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c",
+        "dest": "cargo/vendor/fs_extra-1.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c\", \"files\": {}}",
+        "dest": "cargo/vendor/fs_extra-1.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2420,14 +2589,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gif/gif-0.14.0.crate",
-        "sha256": "f954a9e9159ec994f73a30a12b96a702dde78f5547bcb561174597924f7d4162",
-        "dest": "cargo/vendor/gif-0.14.0"
+        "url": "https://static.crates.io/crates/gif/gif-0.14.1.crate",
+        "sha256": "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e",
+        "dest": "cargo/vendor/gif-0.14.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f954a9e9159ec994f73a30a12b96a702dde78f5547bcb561174597924f7d4162\", \"files\": {}}",
-        "dest": "cargo/vendor/gif-0.14.0",
+        "contents": "{\"package\": \"f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e\", \"files\": {}}",
+        "dest": "cargo/vendor/gif-0.14.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2706,6 +2875,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/http/http-0.2.12.crate",
+        "sha256": "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1",
+        "dest": "cargo/vendor/http-0.2.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1\", \"files\": {}}",
+        "dest": "cargo/vendor/http-0.2.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/http/http-1.4.0.crate",
         "sha256": "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a",
         "dest": "cargo/vendor/http-1.4.0"
@@ -2779,6 +2961,19 @@
         "type": "inline",
         "contents": "{\"package\": \"e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58\", \"files\": {}}",
         "dest": "cargo/vendor/hyper-rustls-0.27.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hyper-tls/hyper-tls-0.6.0.crate",
+        "sha256": "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0",
+        "dest": "cargo/vendor/hyper-tls-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0\", \"files\": {}}",
+        "dest": "cargo/vendor/hyper-tls-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2888,27 +3083,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_properties/icu_properties-2.1.1.crate",
-        "sha256": "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99",
-        "dest": "cargo/vendor/icu_properties-2.1.1"
+        "url": "https://static.crates.io/crates/icu_properties/icu_properties-2.1.2.crate",
+        "sha256": "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec",
+        "dest": "cargo/vendor/icu_properties-2.1.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99\", \"files\": {}}",
-        "dest": "cargo/vendor/icu_properties-2.1.1",
+        "contents": "{\"package\": \"020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_properties-2.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_properties_data/icu_properties_data-2.1.1.crate",
-        "sha256": "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899",
-        "dest": "cargo/vendor/icu_properties_data-2.1.1"
+        "url": "https://static.crates.io/crates/icu_properties_data/icu_properties_data-2.1.2.crate",
+        "sha256": "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af",
+        "dest": "cargo/vendor/icu_properties_data-2.1.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899\", \"files\": {}}",
-        "dest": "cargo/vendor/icu_properties_data-2.1.1",
+        "contents": "{\"package\": \"616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_properties_data-2.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3122,6 +3317,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is-docker/is-docker-0.2.0.crate",
+        "sha256": "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3",
+        "dest": "cargo/vendor/is-docker-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3\", \"files\": {}}",
+        "dest": "cargo/vendor/is-docker-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is-wsl/is-wsl-0.4.0.crate",
+        "sha256": "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5",
+        "dest": "cargo/vendor/is-wsl-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5\", \"files\": {}}",
+        "dest": "cargo/vendor/is-wsl-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/is_terminal_polyfill/is_terminal_polyfill-1.70.2.crate",
         "sha256": "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695",
         "dest": "cargo/vendor/is_terminal_polyfill-1.70.2"
@@ -3130,6 +3351,19 @@
         "type": "inline",
         "contents": "{\"package\": \"a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695\", \"files\": {}}",
         "dest": "cargo/vendor/is_terminal_polyfill-1.70.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itertools/itertools-0.13.0.crate",
+        "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+        "dest": "cargo/vendor/itertools-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186\", \"files\": {}}",
+        "dest": "cargo/vendor/itertools-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3382,27 +3616,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libredox/libredox-0.1.10.crate",
-        "sha256": "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb",
-        "dest": "cargo/vendor/libredox-0.1.10"
+        "url": "https://static.crates.io/crates/libloading/libloading-0.8.9.crate",
+        "sha256": "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55",
+        "dest": "cargo/vendor/libloading-0.8.9"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb\", \"files\": {}}",
-        "dest": "cargo/vendor/libredox-0.1.10",
+        "contents": "{\"package\": \"d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.8.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.15.crate",
-        "sha256": "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.15"
+        "url": "https://static.crates.io/crates/libredox/libredox-0.1.11.crate",
+        "sha256": "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50",
+        "dest": "cargo/vendor/libredox-0.1.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab\", \"files\": {}}",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.15",
+        "contents": "{\"package\": \"df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50\", \"files\": {}}",
+        "dest": "cargo/vendor/libredox-0.1.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3429,6 +3663,19 @@
         "type": "inline",
         "contents": "{\"package\": \"6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77\", \"files\": {}}",
         "dest": "cargo/vendor/litemap-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/litrs/litrs-1.0.0.crate",
+        "sha256": "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092",
+        "dest": "cargo/vendor/litrs-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092\", \"files\": {}}",
+        "dest": "cargo/vendor/litrs-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3629,6 +3876,45 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/minimal-lexical/minimal-lexical-0.2.1.crate",
+        "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a\", \"files\": {}}",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/minimp3/minimp3-0.5.2.crate",
+        "sha256": "9a3ed9d34ed1a9190336a2b165bf09ac447693dfd9a61684597aaae2ee12df53",
+        "dest": "cargo/vendor/minimp3-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9a3ed9d34ed1a9190336a2b165bf09ac447693dfd9a61684597aaae2ee12df53\", \"files\": {}}",
+        "dest": "cargo/vendor/minimp3-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/minimp3-sys/minimp3-sys-0.3.2.crate",
+        "sha256": "e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90",
+        "dest": "cargo/vendor/minimp3-sys-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90\", \"files\": {}}",
+        "dest": "cargo/vendor/minimp3-sys-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.8.9.crate",
         "sha256": "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316",
         "dest": "cargo/vendor/miniz_oxide-0.8.9"
@@ -3642,27 +3928,53 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/mio/mio-1.1.0.crate",
-        "sha256": "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873",
-        "dest": "cargo/vendor/mio-1.1.0"
+        "url": "https://static.crates.io/crates/mio/mio-1.1.1.crate",
+        "sha256": "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc",
+        "dest": "cargo/vendor/mio-1.1.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873\", \"files\": {}}",
-        "dest": "cargo/vendor/mio-1.1.0",
+        "contents": "{\"package\": \"a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc\", \"files\": {}}",
+        "dest": "cargo/vendor/mio-1.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/moxcms/moxcms-0.7.10.crate",
-        "sha256": "80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608",
-        "dest": "cargo/vendor/moxcms-0.7.10"
+        "url": "https://static.crates.io/crates/moxcms/moxcms-0.7.11.crate",
+        "sha256": "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97",
+        "dest": "cargo/vendor/moxcms-0.7.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608\", \"files\": {}}",
-        "dest": "cargo/vendor/moxcms-0.7.10",
+        "contents": "{\"package\": \"ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97\", \"files\": {}}",
+        "dest": "cargo/vendor/moxcms-0.7.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mp3lame-encoder/mp3lame-encoder-0.2.2.crate",
+        "sha256": "5edde3299e6e78f5fb802d2ad566bce5c410a2f99a8562a0dcd6f56e3e77448c",
+        "dest": "cargo/vendor/mp3lame-encoder-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5edde3299e6e78f5fb802d2ad566bce5c410a2f99a8562a0dcd6f56e3e77448c\", \"files\": {}}",
+        "dest": "cargo/vendor/mp3lame-encoder-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mp3lame-sys/mp3lame-sys-0.1.11.crate",
+        "sha256": "54e3b1772db47828840702e5a2e05694527f731abadf9b931355d54035f019d8",
+        "dest": "cargo/vendor/mp3lame-sys-0.1.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"54e3b1772db47828840702e5a2e05694527f731abadf9b931355d54035f019d8\", \"files\": {}}",
+        "dest": "cargo/vendor/mp3lame-sys-0.1.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3676,6 +3988,19 @@
         "type": "inline",
         "contents": "{\"package\": \"01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a\", \"files\": {}}",
         "dest": "cargo/vendor/muda-0.17.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/native-tls/native-tls-0.2.14.crate",
+        "sha256": "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e",
+        "dest": "cargo/vendor/native-tls-0.2.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e\", \"files\": {}}",
+        "dest": "cargo/vendor/native-tls-0.2.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3759,6 +4084,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nom/nom-7.1.3.crate",
+        "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
+        "dest": "cargo/vendor/nom-7.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a\", \"files\": {}}",
+        "dest": "cargo/vendor/nom-7.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/nom/nom-8.0.0.crate",
         "sha256": "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405",
         "dest": "cargo/vendor/nom-8.0.0"
@@ -3793,6 +4131,19 @@
         "type": "inline",
         "contents": "{\"package\": \"a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9\", \"files\": {}}",
         "dest": "cargo/vendor/num-bigint-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.6.crate",
+        "sha256": "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495",
+        "dest": "cargo/vendor/num-complex-0.4.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495\", \"files\": {}}",
+        "dest": "cargo/vendor/num-complex-0.4.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3897,32 +4248,6 @@
         "type": "inline",
         "contents": "{\"package\": \"915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1\", \"files\": {}}",
         "dest": "cargo/vendor/objc-0.2.7",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc-sys/objc-sys-0.3.5.crate",
-        "sha256": "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310",
-        "dest": "cargo/vendor/objc-sys-0.3.5"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310\", \"files\": {}}",
-        "dest": "cargo/vendor/objc-sys-0.3.5",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc2/objc2-0.5.2.crate",
-        "sha256": "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804",
-        "dest": "cargo/vendor/objc2-0.5.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804\", \"files\": {}}",
-        "dest": "cargo/vendor/objc2-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4110,19 +4435,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc2-foundation/objc2-foundation-0.2.2.crate",
-        "sha256": "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8",
-        "dest": "cargo/vendor/objc2-foundation-0.2.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8\", \"files\": {}}",
-        "dest": "cargo/vendor/objc2-foundation-0.2.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/objc2-foundation/objc2-foundation-0.3.2.crate",
         "sha256": "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272",
         "dest": "cargo/vendor/objc2-foundation-0.3.2"
@@ -4157,32 +4469,6 @@
         "type": "inline",
         "contents": "{\"package\": \"2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586\", \"files\": {}}",
         "dest": "cargo/vendor/objc2-javascript-core-0.3.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc2-metal/objc2-metal-0.2.2.crate",
-        "sha256": "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6",
-        "dest": "cargo/vendor/objc2-metal-0.2.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6\", \"files\": {}}",
-        "dest": "cargo/vendor/objc2-metal-0.2.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc2-quartz-core/objc2-quartz-core-0.2.2.crate",
-        "sha256": "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a",
-        "dest": "cargo/vendor/objc2-quartz-core-0.2.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a\", \"files\": {}}",
-        "dest": "cargo/vendor/objc2-quartz-core-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4261,6 +4547,71 @@
         "type": "inline",
         "contents": "{\"package\": \"384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe\", \"files\": {}}",
         "dest": "cargo/vendor/once_cell_polyfill-1.70.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/open/open-5.3.3.crate",
+        "sha256": "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc",
+        "dest": "cargo/vendor/open-5.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc\", \"files\": {}}",
+        "dest": "cargo/vendor/open-5.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl/openssl-0.10.75.crate",
+        "sha256": "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328",
+        "dest": "cargo/vendor/openssl-0.10.75"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-0.10.75",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-macros/openssl-macros-0.1.1.crate",
+        "sha256": "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c",
+        "dest": "cargo/vendor/openssl-macros-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-macros-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-probe/openssl-probe-0.1.6.crate",
+        "sha256": "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e",
+        "dest": "cargo/vendor/openssl-probe-0.1.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-probe-0.1.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.111.crate",
+        "sha256": "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321",
+        "dest": "cargo/vendor/openssl-sys-0.9.111"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-sys-0.9.111",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4391,6 +4742,19 @@
         "type": "inline",
         "contents": "{\"package\": \"35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec\", \"files\": {}}",
         "dest": "cargo/vendor/pastey-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pathdiff/pathdiff-0.2.3.crate",
+        "sha256": "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3",
+        "dest": "cargo/vendor/pathdiff-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3\", \"files\": {}}",
+        "dest": "cargo/vendor/pathdiff-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4747,6 +5111,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.37.crate",
+        "sha256": "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b",
+        "dest": "cargo/vendor/prettyplease-0.2.37"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b\", \"files\": {}}",
+        "dest": "cargo/vendor/prettyplease-0.2.37",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/primal-check/primal-check-0.3.4.crate",
+        "sha256": "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08",
+        "dest": "cargo/vendor/primal-check-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08\", \"files\": {}}",
+        "dest": "cargo/vendor/primal-check-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.3.1.crate",
         "sha256": "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919",
         "dest": "cargo/vendor/proc-macro-crate-1.3.1"
@@ -4864,14 +5254,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/pxfm/pxfm-0.1.26.crate",
-        "sha256": "b3502d6155304a4173a5f2c34b52b7ed0dd085890326cb50fd625fdf39e86b3b",
-        "dest": "cargo/vendor/pxfm-0.1.26"
+        "url": "https://static.crates.io/crates/pxfm/pxfm-0.1.27.crate",
+        "sha256": "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8",
+        "dest": "cargo/vendor/pxfm-0.1.27"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"b3502d6155304a4173a5f2c34b52b7ed0dd085890326cb50fd625fdf39e86b3b\", \"files\": {}}",
-        "dest": "cargo/vendor/pxfm-0.1.26",
+        "contents": "{\"package\": \"7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8\", \"files\": {}}",
+        "dest": "cargo/vendor/pxfm-0.1.27",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5215,6 +5605,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/realfft/realfft-3.5.0.crate",
+        "sha256": "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677",
+        "dest": "cargo/vendor/realfft-3.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677\", \"files\": {}}",
+        "dest": "cargo/vendor/realfft-3.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/recvmsg/recvmsg-1.0.0.crate",
         "sha256": "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175",
         "dest": "cargo/vendor/recvmsg-1.0.0"
@@ -5332,14 +5735,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/reqwest/reqwest-0.12.24.crate",
-        "sha256": "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f",
-        "dest": "cargo/vendor/reqwest-0.12.24"
+        "url": "https://static.crates.io/crates/reqwest/reqwest-0.12.26.crate",
+        "sha256": "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f",
+        "dest": "cargo/vendor/reqwest-0.12.26"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f\", \"files\": {}}",
-        "dest": "cargo/vendor/reqwest-0.12.24",
+        "contents": "{\"package\": \"3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f\", \"files\": {}}",
+        "dest": "cargo/vendor/reqwest-0.12.26",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5371,6 +5774,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rubato/rubato-0.15.0.crate",
+        "sha256": "b5d18b486e7d29a408ef3f825bc1327d8f87af091c987ca2f5b734625940e234",
+        "dest": "cargo/vendor/rubato-0.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b5d18b486e7d29a408ef3f825bc1327d8f87af091c987ca2f5b734625940e234\", \"files\": {}}",
+        "dest": "cargo/vendor/rubato-0.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-2.1.1.crate",
         "sha256": "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d",
         "dest": "cargo/vendor/rustc-hash-2.1.1"
@@ -5397,14 +5813,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustix/rustix-0.38.44.crate",
-        "sha256": "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154",
-        "dest": "cargo/vendor/rustix-0.38.44"
+        "url": "https://static.crates.io/crates/rustfft/rustfft-6.4.1.crate",
+        "sha256": "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89",
+        "dest": "cargo/vendor/rustfft-6.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154\", \"files\": {}}",
-        "dest": "cargo/vendor/rustix-0.38.44",
+        "contents": "{\"package\": \"21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89\", \"files\": {}}",
+        "dest": "cargo/vendor/rustfft-6.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5436,14 +5852,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustls-pki-types/rustls-pki-types-1.13.1.crate",
-        "sha256": "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c",
-        "dest": "cargo/vendor/rustls-pki-types-1.13.1"
+        "url": "https://static.crates.io/crates/rustls-pki-types/rustls-pki-types-1.13.2.crate",
+        "sha256": "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282",
+        "dest": "cargo/vendor/rustls-pki-types-1.13.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c\", \"files\": {}}",
-        "dest": "cargo/vendor/rustls-pki-types-1.13.1",
+        "contents": "{\"package\": \"21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-pki-types-1.13.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5496,6 +5912,19 @@
         "type": "inline",
         "contents": "{\"package\": \"93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502\", \"files\": {}}",
         "dest": "cargo/vendor/same-file-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schannel/schannel-0.1.28.crate",
+        "sha256": "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1",
+        "dest": "cargo/vendor/schannel-0.1.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1\", \"files\": {}}",
+        "dest": "cargo/vendor/schannel-0.1.28",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5561,6 +5990,32 @@
         "type": "inline",
         "contents": "{\"package\": \"94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49\", \"files\": {}}",
         "dest": "cargo/vendor/scopeguard-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/security-framework/security-framework-2.11.1.crate",
+        "sha256": "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02",
+        "dest": "cargo/vendor/security-framework-2.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02\", \"files\": {}}",
+        "dest": "cargo/vendor/security-framework-2.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/security-framework-sys/security-framework-sys-2.15.0.crate",
+        "sha256": "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0",
+        "dest": "cargo/vendor/security-framework-sys-2.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0\", \"files\": {}}",
+        "dest": "cargo/vendor/security-framework-sys-2.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5696,14 +6151,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.0.3.crate",
-        "sha256": "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392",
-        "dest": "cargo/vendor/serde_spanned-1.0.3"
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.0.4.crate",
+        "sha256": "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776",
+        "dest": "cargo/vendor/serde_spanned-1.0.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_spanned-1.0.3",
+        "contents": "{\"package\": \"f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5813,6 +6268,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook/signal-hook-0.3.18.crate",
+        "sha256": "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2",
+        "dest": "cargo/vendor/signal-hook-0.3.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-0.3.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook-mio/signal-hook-mio-0.2.5.crate",
+        "sha256": "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc",
+        "dest": "cargo/vendor/signal-hook-mio-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-mio-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.7.crate",
         "sha256": "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad",
         "dest": "cargo/vendor/signal-hook-registry-1.4.7"
@@ -5826,14 +6307,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/simd-adler32/simd-adler32-0.3.7.crate",
-        "sha256": "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe",
-        "dest": "cargo/vendor/simd-adler32-0.3.7"
+        "url": "https://static.crates.io/crates/simd-adler32/simd-adler32-0.3.8.crate",
+        "sha256": "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2",
+        "dest": "cargo/vendor/simd-adler32-0.3.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe\", \"files\": {}}",
-        "dest": "cargo/vendor/simd-adler32-0.3.7",
+        "contents": "{\"package\": \"e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2\", \"files\": {}}",
+        "dest": "cargo/vendor/simd-adler32-0.3.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5891,6 +6372,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slice-ring-buffer/slice-ring-buffer-0.3.4.crate",
+        "sha256": "84ae312bda09b2368f79f985fdb4df4a0b5cbc75546b511303972d195f8c27d6",
+        "dest": "cargo/vendor/slice-ring-buffer-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"84ae312bda09b2368f79f985fdb4df4a0b5cbc75546b511303972d195f8c27d6\", \"files\": {}}",
+        "dest": "cargo/vendor/slice-ring-buffer-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/smallvec/smallvec-1.15.1.crate",
         "sha256": "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03",
         "dest": "cargo/vendor/smallvec-1.15.1"
@@ -5917,14 +6411,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/softbuffer/softbuffer-0.4.6.crate",
-        "sha256": "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08",
-        "dest": "cargo/vendor/softbuffer-0.4.6"
+        "url": "https://static.crates.io/crates/softbuffer/softbuffer-0.4.8.crate",
+        "sha256": "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3",
+        "dest": "cargo/vendor/softbuffer-0.4.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08\", \"files\": {}}",
-        "dest": "cargo/vendor/softbuffer-0.4.6",
+        "contents": "{\"package\": \"aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3\", \"files\": {}}",
+        "dest": "cargo/vendor/softbuffer-0.4.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5977,6 +6471,19 @@
         "type": "inline",
         "contents": "{\"package\": \"a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f\", \"files\": {}}",
         "dest": "cargo/vendor/static_assertions-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strength_reduce/strength_reduce-0.2.4.crate",
+        "sha256": "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82",
+        "dest": "cargo/vendor/strength_reduce-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82\", \"files\": {}}",
+        "dest": "cargo/vendor/strength_reduce-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6151,14 +6658,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tauri/tauri-2.9.4.crate",
-        "sha256": "15524fc7959bfcaa051ba6d0b3fb1ef18e978de2176c7c6acb977f7fd14d35c7",
-        "dest": "cargo/vendor/tauri-2.9.4"
+        "url": "https://static.crates.io/crates/tauri/tauri-2.9.5.crate",
+        "sha256": "8a3868da5508446a7cd08956d523ac3edf0a8bc20bf7e4038f9a95c2800d2033",
+        "dest": "cargo/vendor/tauri-2.9.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"15524fc7959bfcaa051ba6d0b3fb1ef18e978de2176c7c6acb977f7fd14d35c7\", \"files\": {}}",
-        "dest": "cargo/vendor/tauri-2.9.4",
+        "contents": "{\"package\": \"8a3868da5508446a7cd08956d523ac3edf0a8bc20bf7e4038f9a95c2800d2033\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-2.9.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6216,6 +6723,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-clipboard-manager/tauri-plugin-clipboard-manager-2.3.2.crate",
+        "sha256": "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf",
+        "dest": "cargo/vendor/tauri-plugin-clipboard-manager-2.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-clipboard-manager-2.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tauri-plugin-global-shortcut/tauri-plugin-global-shortcut-2.3.1.crate",
         "sha256": "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405",
         "dest": "cargo/vendor/tauri-plugin-global-shortcut-2.3.1"
@@ -6224,6 +6744,19 @@
         "type": "inline",
         "contents": "{\"package\": \"424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405\", \"files\": {}}",
         "dest": "cargo/vendor/tauri-plugin-global-shortcut-2.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-opener/tauri-plugin-opener-2.5.2.crate",
+        "sha256": "c26b72571d25dee25667940027114e60f569fc3974f8cefbe50c2cbc5fd65e3b",
+        "dest": "cargo/vendor/tauri-plugin-opener-2.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c26b72571d25dee25667940027114e60f569fc3974f8cefbe50c2cbc5fd65e3b\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-opener-2.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6242,6 +6775,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-store/tauri-plugin-store-2.4.1.crate",
+        "sha256": "59a77036340a97eb5bbe1b3209c31e5f27f75e6f92a52fd9dd4b211ef08bf310",
+        "dest": "cargo/vendor/tauri-plugin-store-2.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"59a77036340a97eb5bbe1b3209c31e5f27f75e6f92a52fd9dd4b211ef08bf310\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-store-2.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tauri-runtime/tauri-runtime-2.9.2.crate",
         "sha256": "87f766fe9f3d1efc4b59b17e7a891ad5ed195fa8d23582abb02e6c9a01137892",
         "dest": "cargo/vendor/tauri-runtime-2.9.2"
@@ -6255,14 +6801,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tauri-runtime-wry/tauri-runtime-wry-2.9.2.crate",
-        "sha256": "7950f3bde6bcca6655bc5e76d3d6ec587ceb81032851ab4ddbe1f508bdea2729",
-        "dest": "cargo/vendor/tauri-runtime-wry-2.9.2"
+        "url": "https://static.crates.io/crates/tauri-runtime-wry/tauri-runtime-wry-2.9.3.crate",
+        "sha256": "187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065",
+        "dest": "cargo/vendor/tauri-runtime-wry-2.9.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7950f3bde6bcca6655bc5e76d3d6ec587ceb81032851ab4ddbe1f508bdea2729\", \"files\": {}}",
-        "dest": "cargo/vendor/tauri-runtime-wry-2.9.2",
+        "contents": "{\"package\": \"187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-runtime-wry-2.9.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6489,6 +7035,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-native-tls/tokio-native-tls-0.3.1.crate",
+        "sha256": "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2",
+        "dest": "cargo/vendor/tokio-native-tls-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-native-tls-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-rustls/tokio-rustls-0.26.4.crate",
         "sha256": "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61",
         "dest": "cargo/vendor/tokio-rustls-0.26.4"
@@ -6528,14 +7087,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml/toml-0.9.8.crate",
-        "sha256": "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8",
-        "dest": "cargo/vendor/toml-0.9.8"
+        "url": "https://static.crates.io/crates/toml/toml-0.9.10+spec-1.1.0.crate",
+        "sha256": "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48",
+        "dest": "cargo/vendor/toml-0.9.10+spec-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8\", \"files\": {}}",
-        "dest": "cargo/vendor/toml-0.9.8",
+        "contents": "{\"package\": \"0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.9.10+spec-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6554,14 +7113,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.7.3.crate",
-        "sha256": "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533",
-        "dest": "cargo/vendor/toml_datetime-0.7.3"
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.7.5+spec-1.1.0.crate",
+        "sha256": "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347",
+        "dest": "cargo/vendor/toml_datetime-0.7.5+spec-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_datetime-0.7.3",
+        "contents": "{\"package\": \"92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-0.7.5+spec-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6593,40 +7152,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.23.7.crate",
-        "sha256": "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d",
-        "dest": "cargo/vendor/toml_edit-0.23.7"
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.23.10+spec-1.0.0.crate",
+        "sha256": "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269",
+        "dest": "cargo/vendor/toml_edit-0.23.10+spec-1.0.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.23.7",
+        "contents": "{\"package\": \"84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.23.10+spec-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.0.4.crate",
-        "sha256": "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e",
-        "dest": "cargo/vendor/toml_parser-1.0.4"
+        "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.0.6+spec-1.1.0.crate",
+        "sha256": "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44",
+        "dest": "cargo/vendor/toml_parser-1.0.6+spec-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_parser-1.0.4",
+        "contents": "{\"package\": \"a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_parser-1.0.6+spec-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.0.4.crate",
-        "sha256": "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2",
-        "dest": "cargo/vendor/toml_writer-1.0.4"
+        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.0.6+spec-1.1.0.crate",
+        "sha256": "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607",
+        "dest": "cargo/vendor/toml_writer-1.0.6+spec-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_writer-1.0.4",
+        "contents": "{\"package\": \"ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_writer-1.0.6+spec-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6645,14 +7204,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tower-http/tower-http-0.6.7.crate",
-        "sha256": "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456",
-        "dest": "cargo/vendor/tower-http-0.6.7"
+        "url": "https://static.crates.io/crates/tower-http/tower-http-0.6.8.crate",
+        "sha256": "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8",
+        "dest": "cargo/vendor/tower-http-0.6.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456\", \"files\": {}}",
-        "dest": "cargo/vendor/tower-http-0.6.7",
+        "contents": "{\"package\": \"d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-http-0.6.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6684,14 +7243,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tracing/tracing-0.1.43.crate",
-        "sha256": "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647",
-        "dest": "cargo/vendor/tracing-0.1.43"
+        "url": "https://static.crates.io/crates/tracing/tracing-0.1.44.crate",
+        "sha256": "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100",
+        "dest": "cargo/vendor/tracing-0.1.44"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647\", \"files\": {}}",
-        "dest": "cargo/vendor/tracing-0.1.43",
+        "contents": "{\"package\": \"63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-0.1.44",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6710,14 +7269,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.35.crate",
-        "sha256": "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c",
-        "dest": "cargo/vendor/tracing-core-0.1.35"
+        "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.36.crate",
+        "sha256": "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a",
+        "dest": "cargo/vendor/tracing-core-0.1.36"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c\", \"files\": {}}",
-        "dest": "cargo/vendor/tracing-core-0.1.35",
+        "contents": "{\"package\": \"db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-core-0.1.36",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/transpose/transpose-0.2.3.crate",
+        "sha256": "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e",
+        "dest": "cargo/vendor/transpose-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e\", \"files\": {}}",
+        "dest": "cargo/vendor/transpose-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7004,6 +7576,19 @@
         "type": "inline",
         "contents": "{\"package\": \"666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2\", \"files\": {}}",
         "dest": "cargo/vendor/v_frame-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vcpkg/vcpkg-0.2.15.crate",
+        "sha256": "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426",
+        "dest": "cargo/vendor/vcpkg-0.2.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426\", \"files\": {}}",
+        "dest": "cargo/vendor/vcpkg-0.2.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -7308,6 +7893,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webdriver/webdriver-0.50.0.crate",
+        "sha256": "144ab979b12d36d65065635e646549925de229954de2eb3b47459b432a42db71",
+        "dest": "cargo/vendor/webdriver-0.50.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"144ab979b12d36d65065635e646549925de229954de2eb3b47459b432a42db71\", \"files\": {}}",
+        "dest": "cargo/vendor/webdriver-0.50.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/webkit2gtk/webkit2gtk-2.0.1.crate",
         "sha256": "76b1bc1e54c581da1e9f179d0b38512ba358fb1af2d634a1affe42e37172361a",
         "dest": "cargo/vendor/webkit2gtk-2.0.1"
@@ -7394,6 +7992,32 @@
         "type": "inline",
         "contents": "{\"package\": \"a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88\", \"files\": {}}",
         "dest": "cargo/vendor/weezl-0.1.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/whisper-rs/whisper-rs-0.15.1.crate",
+        "sha256": "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8",
+        "dest": "cargo/vendor/whisper-rs-0.15.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8\", \"files\": {}}",
+        "dest": "cargo/vendor/whisper-rs-0.15.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/whisper-rs-sys/whisper-rs-sys-0.14.1.crate",
+        "sha256": "b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2",
+        "dest": "cargo/vendor/whisper-rs-sys-0.14.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2\", \"files\": {}}",
+        "dest": "cargo/vendor/whisper-rs-sys-0.14.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8296,14 +8920,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wl-clipboard-rs/wl-clipboard-rs-0.9.2.crate",
-        "sha256": "8e5ff8d0e60065f549fafd9d6cb626203ea64a798186c80d8e7df4f8af56baeb",
-        "dest": "cargo/vendor/wl-clipboard-rs-0.9.2"
+        "url": "https://static.crates.io/crates/wl-clipboard-rs/wl-clipboard-rs-0.9.3.crate",
+        "sha256": "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3",
+        "dest": "cargo/vendor/wl-clipboard-rs-0.9.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8e5ff8d0e60065f549fafd9d6cb626203ea64a798186c80d8e7df4f8af56baeb\", \"files\": {}}",
-        "dest": "cargo/vendor/wl-clipboard-rs-0.9.2",
+        "contents": "{\"package\": \"e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3\", \"files\": {}}",
+        "dest": "cargo/vendor/wl-clipboard-rs-0.9.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -8634,14 +9258,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zune-jpeg/zune-jpeg-0.5.5.crate",
-        "sha256": "dc6fb7703e32e9a07fb3f757360338b3a567a5054f21b5f52a666752e333d58e",
-        "dest": "cargo/vendor/zune-jpeg-0.5.5"
+        "url": "https://static.crates.io/crates/zune-jpeg/zune-jpeg-0.5.7.crate",
+        "sha256": "51d915729b0e7d5fe35c2f294c5dc10b30207cc637920e5b59077bfa3da63f28",
+        "dest": "cargo/vendor/zune-jpeg-0.5.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dc6fb7703e32e9a07fb3f757360338b3a567a5054f21b5f52a666752e333d58e\", \"files\": {}}",
-        "dest": "cargo/vendor/zune-jpeg-0.5.5",
+        "contents": "{\"package\": \"51d915729b0e7d5fe35c2f294c5dc10b30207cc637920e5b59077bfa3da63f28\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-jpeg-0.5.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/ink.whis.Whis.desktop
+++ b/ink.whis.Whis.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Whis
+Comment=Voice-to-text transcription with global shortcuts
+Exec=whis-desktop
+Icon=ink.whis.Whis
+Terminal=false
+Type=Application
+Categories=Utility;Audio;
+Keywords=voice;transcription;whisper;speech;
+StartupWMClass=ink.whis.Whis
+StartupNotify=true

--- a/ink.whis.Whis.metainfo.xml
+++ b/ink.whis.Whis.metainfo.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>ink.whis.Whis</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Whis</name>
+  <summary>Turn speech into text</summary>
+  <description>
+    <p>Whis is a desktop application that transcribes your voice to text using OpenAI's Whisper API. Press a global shortcut to start recording, release to transcribe, and the text is automatically copied to your clipboard.</p>
+    <p>Features:</p>
+    <ul>
+      <li>Global keyboard shortcut (works in any application)</li>
+      <li>System tray integration with recording status</li>
+      <li>Automatic clipboard paste</li>
+      <li>X11 and Wayland support</li>
+    </ul>
+  </description>
+  <url type="homepage">https://whis.ink</url>
+  <url type="bugtracker">https://github.com/frankdierolf/whis/issues</url>
+  <url type="vcs-browser">https://github.com/frankdierolf/whis</url>
+  <launchable type="desktop-id">ink.whis.Whis.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/frankdierolf/whis/5d1fd2f/crates/whis-desktop/screenshots/1-about.png</image>
+      <caption>Your voice, piped to clipboard</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/frankdierolf/whis/5d1fd2f/crates/whis-desktop/screenshots/2-tray.png</image>
+      <caption>System tray integration</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/frankdierolf/whis/5d1fd2f/crates/whis-desktop/screenshots/3-home.png</image>
+      <caption>Start recording from the home screen</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/frankdierolf/whis/5d1fd2f/crates/whis-desktop/screenshots/4-shortcuts.png</image>
+      <caption>Configure global keyboard shortcuts</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/frankdierolf/whis/5d1fd2f/crates/whis-desktop/screenshots/5-settings-cloud.png</image>
+      <caption>Cloud transcription providers</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/frankdierolf/whis/5d1fd2f/crates/whis-desktop/screenshots/6-settings-local.png</image>
+      <caption>Local Whisper transcription</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/frankdierolf/whis/5d1fd2f/crates/whis-desktop/screenshots/7-presets.png</image>
+      <caption>AI post-processing presets</caption>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.6.0" date="2025-12-23">
+      <description>
+        <p>Local Transcription &amp; Multi-Platform Support</p>
+        <ul>
+          <li>Local whisper transcription via whisper.cpp (fully offline)</li>
+          <li>AI post-processing with Ollama support</li>
+          <li>Preset system: ai-prompt, email, default + custom</li>
+          <li>Setup wizard: whis setup cloud/local</li>
+          <li>Android app (alpha) with cloud transcription</li>
+          <li>Multi-platform builds: Linux ARM64, macOS Intel/ARM, Windows</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.9" date="2025-12-11">
+      <description>
+        <p>Multi-provider transcription</p>
+        <ul>
+          <li>Choose between OpenAI Whisper and Mistral Voxtral providers</li>
+          <li>Add language hint support (ISO-639-1 codes)</li>
+          <li>Desktop settings panel with provider selection</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.8" date="2025-12-03">
+      <description>
+        <p>Full cross-platform support and Linux ARM64</p>
+        <ul>
+          <li>Windows and macOS CLI now fully supported</li>
+          <li>Linux ARM64 support (Raspberry Pi, AWS Graviton)</li>
+          <li>Cross-platform IPC and hotkey support</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.7" date="2025-12-03">
+      <description>
+        <p>Smart close behavior</p>
+        <ul>
+          <li>Window quits if no way to reopen (no tray and no shortcut)</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.6" date="2025-12-03">
+      <description>
+        <p>AppImage install/uninstall and no-tray support</p>
+        <ul>
+          <li>Add --install and --uninstall CLI flags for AppImage</li>
+          <li>Support desktop environments without system tray</li>
+          <li>Fix Wayland window matching with StartupWMClass</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.5" date="2025-12-02">
+      <description>
+        <p>Improved naming conventions</p>
+        <ul>
+          <li>Rename Config to ApiConfig for clarity</li>
+          <li>Rename AudioResult to RecordingOutput</li>
+          <li>Various internal naming improvements</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.4" date="2025-12-01">
+      <description>
+        <p>Bundle wl-clipboard in Flatpak for GNOME compatibility</p>
+        <ul>
+          <li>Use bundled wl-copy instead of flatpak-spawn</li>
+          <li>No longer requires sandbox escape permission</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.3" date="2025-12-01">
+      <description>
+        <p>GNOME clipboard compatibility fix</p>
+        <ul>
+          <li>Use flatpak-spawn for clipboard (GNOME doesn't support wlr-data-control)</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.2" date="2025-12-01">
+      <description>
+        <p>Flathub release with improved sandbox compatibility</p>
+        <ul>
+          <li>Use Wayland data-control protocol for clipboard</li>
+          <li>Renamed app ID to ink.whis.Whis</li>
+          <li>Removed unnecessary permissions</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.5.0" date="2025-11-30">
+      <description>
+        <p>Initial Flatpak release with desktop application</p>
+        <ul>
+          <li>System tray with global shortcut support</li>
+          <li>Vue 3.6 settings UI</li>
+          <li>X11 and Wayland support via XDG Portal</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+  <developer id="ink.whis">
+    <name>Frank Dierolf</name>
+  </developer>
+  <branding>
+    <color type="primary" scheme_preference="light">#FFE066</color>
+    <color type="primary" scheme_preference="dark">#B38F00</color>
+  </branding>
+  <categories>
+    <category>Utility</category>
+    <category>Audio</category>
+  </categories>
+  <keywords>
+    <keyword>voice</keyword>
+    <keyword>transcription</keyword>
+    <keyword>whisper</keyword>
+    <keyword>speech-to-text</keyword>
+  </keywords>
+</component>

--- a/ink.whis.Whis.yaml
+++ b/ink.whis.Whis.yaml
@@ -25,6 +25,7 @@ build-options:
     CARGO_HOME: /run/build/whis-desktop/cargo
     XDG_CACHE_HOME: /run/build/whis-desktop/flatpak-node/cache
     npm_config_cache: /run/build/whis-desktop/flatpak-node/npm-cache
+    WHISPER_DONT_GENERATE_BINDINGS: "1"
 
 modules:
   # System tray indicator support (from shared-modules)
@@ -52,9 +53,9 @@ modules:
       - cargo build --release -p whis-desktop --offline
       # Install binary
       - install -Dm755 target/release/whis-desktop /app/bin/whis-desktop
-      # Install metadata (from packaging/linux/)
-      - install -Dm644 crates/whis-desktop/packaging/linux/ink.whis.Whis.metainfo.xml /app/share/metainfo/ink.whis.Whis.metainfo.xml
-      - install -Dm644 crates/whis-desktop/packaging/linux/ink.whis.Whis.desktop /app/share/applications/ink.whis.Whis.desktop
+      # Install metadata
+      - install -Dm644 ink.whis.Whis.metainfo.xml /app/share/metainfo/ink.whis.Whis.metainfo.xml
+      - install -Dm644 ink.whis.Whis.desktop /app/share/applications/ink.whis.Whis.desktop
       # Install icons
       - install -Dm644 crates/whis-desktop/icons/22x22.png /app/share/icons/hicolor/22x22/apps/ink.whis.Whis.png
       - install -Dm644 crates/whis-desktop/icons/48x48.png /app/share/icons/hicolor/48x48/apps/ink.whis.Whis.png
@@ -68,7 +69,11 @@ modules:
     sources:
       - type: git
         url: https://github.com/frankdierolf/whis.git
-        tag: v0.5.8
-        commit: 19d4acfc9eb093ee069555fbc6bf4907e99f8d68
+        tag: v0.6.0
+        commit: 5d1fd2f67a484dd12ecbb7cdd38c3fea5dba497b
       - cargo-sources.json
       - node-sources.json
+      - type: file
+        path: ink.whis.Whis.desktop
+      - type: file
+        path: ink.whis.Whis.metainfo.xml

--- a/node-sources.json
+++ b/node-sources.json
@@ -1,43 +1,57 @@
 [
     {
         "type": "archive",
-        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
         "strip-components": 1,
-        "sha512": "b7be972d00e9c609aad9c35729354407b3bb60c6f8d9ab63d917b61da7f8e4791a5298ccd89d14b89643b9a19b3db6a6cd9edb6b0c8615492874bfb3704fa3bd",
-        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.27.0",
+        "sha512": "89e3080f4251658fd9782aec150dd8dcd947342a88853a6b25f0e0481dff96fe63259f055f786a3f25d685efa0bd2e4044c049db8d8f33e54dcff72d363fff78",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.27.1",
         "only-arches": [
             "arm"
         ]
     },
     {
         "type": "archive",
-        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
         "strip-components": 1,
-        "sha512": "012d7cbf457ebd988b2728bfe0ba61bc113e3885faf363eeed960db1d507c94292a11c1d9ceb0c7fa1437a4c2800529e8f5e1602439e7f7cc039126002d5e795",
-        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.27.0",
+        "sha512": "5bdfff902ae1ffa8a7f6b58805d29a32db934f3363ea349e1bf85a581003a8b2daf4ff0ee584910f3803e72f500689380189734ba0111e27c06fbe55e86ebbd1",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.27.1",
         "only-arches": [
             "aarch64"
         ]
     },
     {
         "type": "archive",
-        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
         "strip-components": 1,
-        "sha512": "333d63c6a9bf91f80a91cfca2c70b9a88ba332f9e76ab0fdadad5c11caeceeab214d44a4b0f8a11ab587546e7ea2c00843af39efb669c30ed219aa66cd2b7837",
-        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.27.0",
+        "sha512": "548515e33f060fcaed49531f023d5a5c56a1b22ffeb5ca175cd6265e0cc848bf8a077f35bdb49335d7991c71c862a1725dca0486ef67e5c4fed39b51bf5deb97",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.27.1",
         "only-arches": [
             "i386"
         ]
     },
     {
         "type": "archive",
-        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
         "strip-components": 1,
-        "sha512": "d61056c78394244d9c69bfbe69567ba4e6c3eacf832b898f1a97a6b6700e441bdbe65fe0e71146934bdcd0f8d292b0ecd176978fdcb2a1bdddd785eabe743883",
-        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.27.0",
+        "sha512": "cf71ff1d823d30cd074efde1419f357fe00a6fec84a0246551bcb517cd2f6d0e5777310cc98ffd88d9409a1aa204ac383095f07e0b21ec444610e86b3359e230",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.27.1",
         "only-arches": [
             "x86_64"
         ]
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@antfu/eslint-config/-/eslint-config-6.7.1.tgz",
+        "sha512": "fbc18832639faed0155e8a952bdb1fa2f0251cf929df98a59eda99e979683bf46dcb7ea03b169af1dbf00a1f3f7aac3022c96803f843268dc47fde5345b77212",
+        "dest-filename": "8832639faed0155e8a952bdb1fa2f0251cf929df98a59eda99e979683bf46dcb7ea03b169af1dbf00a1f3f7aac3022c96803f843268dc47fde5345b77212",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/c1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+        "sha512": "30642c9b0d7467223e109a38e42752111e3311bfa9df52e90c0169d99de0912775caa5591a2d046f1fbe61310ca27272e280a110c2ecc59eb88fc147eac4aab5",
+        "dest-filename": "2c9b0d7467223e109a38e42752111e3311bfa9df52e90c0169d99de0912775caa5591a2d046f1fbe61310ca27272e280a110c2ecc59eb88fc147eac4aab5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/64"
     },
     {
         "type": "file",
@@ -69,6 +83,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
+        "sha512": "a77cb41483b06984543d170c3bbf9d9662e1f0f49172b8ee4e776c880d160056d6112d262d996b8d5a01459f43ce43c52591ba2869099a810063465c5564e4a3",
+        "dest-filename": "b41483b06984543d170c3bbf9d9662e1f0f49172b8ee4e776c880d160056d6112d262d996b8d5a01459f43ce43c52591ba2869099a810063465c5564e4a3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/7c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
+        "sha512": "a4c37915cac4c3d8549190387feccb9738af4127907f97511898d251bbd56032efa4a09d431e4e6a49ef2b381bb573a2ce13fe4892498ea11b39ee79b8a29f03",
+        "dest-filename": "7915cac4c3d8549190387feccb9738af4127907f97511898d251bbd56032efa4a09d431e4e6a49ef2b381bb573a2ce13fe4892498ea11b39ee79b8a29f03",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/c3"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
         "sha512": "a35ba15004b2a3ddb5af65ed1d8387cbb81d9062e07bc8210444073169b2245a17969539f2422b861377c36ea5a506fa76ca5eb7079aa4c9f609237043c238c2",
         "dest-filename": "a15004b2a3ddb5af65ed1d8387cbb81d9062e07bc8210444073169b2245a17969539f2422b861377c36ea5a506fa76ca5eb7079aa4c9f609237043c238c2",
@@ -90,185 +118,318 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-        "sha512": "2ae66b7768518f3d35cb924af66101483dd58f799b0af7a6853e3aeab4ae258784fe18ee06b1df8e372331d4e6feccfb6aefbefac75b259266b81c102eec3af0",
-        "dest-filename": "6b7768518f3d35cb924af66101483dd58f799b0af7a6853e3aeab4ae258784fe18ee06b1df8e372331d4e6feccfb6aefbefac75b259266b81c102eec3af0",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/e6"
+        "url": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.76.0.tgz",
+        "sha512": "83e46286dcc58064f1d96602b931db74e5c97809469d13b0b344de00bc7da30fd998e44e399915839c29fc1e389f4589808e124053f57963368913e5536635e3",
+        "dest-filename": "6286dcc58064f1d96602b931db74e5c97809469d13b0b344de00bc7da30fd998e44e399915839c29fc1e389f4589808e124053f57963368913e5536635e3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/e4"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-        "sha512": "8faeda7b3acf35858910e1d434b3e3f6669e26d7bbb9230cea0328c5f3c2f613a0f0dd3626e422fd3edec2e99fe2d36f25a74592f2d932502aef76fdbb074cc9",
-        "dest-filename": "da7b3acf35858910e1d434b3e3f6669e26d7bbb9230cea0328c5f3c2f613a0f0dd3626e422fd3edec2e99fe2d36f25a74592f2d932502aef76fdbb074cc9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/ae"
+        "url": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.78.0.tgz",
+        "sha512": "ad0914e6ef21340ab63554731e721452f47a6ab6ced1be803a5be94cd4b8f029222929ffc6d35f3b304adb7244e12896f3d0e0bd4ec6b712d5815e159f61c103",
+        "dest-filename": "14e6ef21340ab63554731e721452f47a6ab6ced1be803a5be94cd4b8f029222929ffc6d35f3b304adb7244e12896f3d0e0bd4ec6b712d5815e159f61c103",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/09"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-        "sha512": "082defb78fb5c59aecf7bfcf283925d3237bc3c79dbd4daf66f005183d7a9fd1740af9e2cb9aafcd15e37ced65f7879f733924404ea0d71d22ef741fe6eb6139",
-        "dest-filename": "efb78fb5c59aecf7bfcf283925d3237bc3c79dbd4daf66f005183d7a9fd1740af9e2cb9aafcd15e37ced65f7879f733924404ea0d71d22ef741fe6eb6139",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/08/2d"
+        "url": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+        "sha512": "43d863c56239c4133ea96d9e9f17def300ca74558c7ddd19dbd9396499ee06a0ff09ab18e59af28f4f5a080ea8c1b1804d6cfedfda79b8875a1d7a68a4e706f2",
+        "dest-filename": "63c56239c4133ea96d9e9f17def300ca74558c7ddd19dbd9396499ee06a0ff09ab18e59af28f4f5a080ea8c1b1804d6cfedfda79b8875a1d7a68a4e706f2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/d8"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-        "sha512": "c2eacc905d679906a304ed7ed0226670dd7b53804fe86a8d49138ff2dd17fc98b0da5b5818b1e9124b29f4ca6806a92b151de4bf6fed7ba4a16b6ea4dfec99f5",
-        "dest-filename": "cc905d679906a304ed7ed0226670dd7b53804fe86a8d49138ff2dd17fc98b0da5b5818b1e9124b29f4ca6806a92b151de4bf6fed7ba4a16b6ea4dfec99f5",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/ea"
+        "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
+        "sha512": "1c7079d2976c057ea4e3b4b8bb983f09a2e3a92deac1a39513920bb2aeb88f2ce03212ee0ae67cac6cccf7286c0237e391b8143cccd910f6bb0c0a7bcb3eafb8",
+        "dest-filename": "79d2976c057ea4e3b4b8bb983f09a2e3a92deac1a39513920bb2aeb88f2ce03212ee0ae67cac6cccf7286c0237e391b8143cccd910f6bb0c0a7bcb3eafb8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/70"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-        "sha512": "b8939029809c1e1834ec32fb8bc3338ef4b62da3fb5bb3e7ffbb80d01e52d449ea022ac9b5bcb0e320b98d0e6a7058c72bd97aa3f317f508ac060d7690d91d1e",
-        "dest-filename": "9029809c1e1834ec32fb8bc3338ef4b62da3fb5bb3e7ffbb80d01e52d449ea022ac9b5bcb0e320b98d0e6a7058c72bd97aa3f317f508ac060d7690d91d1e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/93"
+        "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
+        "sha512": "905a9aebf51c6936c69bf36770df64cd538e0e38595bc7be1517527b2a567ba8f7de0cdc947b7094036cdba26bba93a7b65716981d2ef3ef07668f2ceed847be",
+        "dest-filename": "9aebf51c6936c69bf36770df64cd538e0e38595bc7be1517527b2a567ba8f7de0cdc947b7094036cdba26bba93a7b65716981d2ef3ef07668f2ceed847be",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/5a"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-        "sha512": "f261ba6ab1f7c81ff86578849d7a1fe4c2bbd9d13acccf5c0ef51c3edc61519b038c44a5f498a96585bad02dc91ab78a0843fea7c3ffef6afaf66e0064625de6",
-        "dest-filename": "ba6ab1f7c81ff86578849d7a1fe4c2bbd9d13acccf5c0ef51c3edc61519b038c44a5f498a96585bad02dc91ab78a0843fea7c3ffef6afaf66e0064625de6",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/61"
+        "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
+        "sha512": "e397ee2a6009a719d05a2c4e182ad2faba3852f6f845ef7e51389e518d9ff0011cfadedde00699e9e509dc7bdaeddb6bc400161ed94416c5c530080d9c653db9",
+        "dest-filename": "ee2a6009a719d05a2c4e182ad2faba3852f6f845ef7e51389e518d9ff0011cfadedde00699e9e509dc7bdaeddb6bc400161ed94416c5c530080d9c653db9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/97"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-        "sha512": "f451edc8ef7cf02c0d30c384dd821e722f9457ec79672f1f236a87369b04b5217cdd83c1984f145a67d801083a531ec6b2677815e8d9aa711464230668d40743",
-        "dest-filename": "edc8ef7cf02c0d30c384dd821e722f9457ec79672f1f236a87369b04b5217cdd83c1984f145a67d801083a531ec6b2677815e8d9aa711464230668d40743",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/51"
+        "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
+        "sha512": "2c11293b3d01b2030478781e9dfe5aaa69ff94b35315755fa16314a31f02b565982bd5f88e64335a3a06a0d6fc9660189a5fed43f62cbe6f2aeecceeec1a3145",
+        "dest-filename": "293b3d01b2030478781e9dfe5aaa69ff94b35315755fa16314a31f02b565982bd5f88e64335a3a06a0d6fc9660189a5fed43f62cbe6f2aeecceeec1a3145",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/11"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-        "sha512": "cc231e3172381d2fed5ef273f2f5867b1a598f6615b510228472e4d629998f879fc75050ccdefa60578aaa50ebddb516236eb01f02d63dddebc21ea97b8115ee",
-        "dest-filename": "1e3172381d2fed5ef273f2f5867b1a598f6615b510228472e4d629998f879fc75050ccdefa60578aaa50ebddb516236eb01f02d63dddebc21ea97b8115ee",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/23"
+        "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
+        "sha512": "bde83b7cbf1e31209528bec85b8a716f9e10111b5e7450df63f012aee98afd26c5b179d16b3c58e18ca437f4c762a1671702746958e252b546d8fc1c74012a41",
+        "dest-filename": "3b7cbf1e31209528bec85b8a716f9e10111b5e7450df63f012aee98afd26c5b179d16b3c58e18ca437f4c762a1671702746958e252b546d8fc1c74012a41",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/e8"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-        "sha512": "b7be972d00e9c609aad9c35729354407b3bb60c6f8d9ab63d917b61da7f8e4791a5298ccd89d14b89643b9a19b3db6a6cd9edb6b0c8615492874bfb3704fa3bd",
-        "dest-filename": "972d00e9c609aad9c35729354407b3bb60c6f8d9ab63d917b61da7f8e4791a5298ccd89d14b89643b9a19b3db6a6cd9edb6b0c8615492874bfb3704fa3bd",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/be"
+        "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
+        "sha512": "fb710b77e9d3ce17d66f4ed5a25ec467ee4f4db27fbbbe270ba8afe3f970214f7d229e6eb98e90a087f41e7e26d87a15d2a727462bcddca4aa73e1720878e855",
+        "dest-filename": "0b77e9d3ce17d66f4ed5a25ec467ee4f4db27fbbbe270ba8afe3f970214f7d229e6eb98e90a087f41e7e26d87a15d2a727462bcddca4aa73e1720878e855",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/71"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-        "sha512": "012d7cbf457ebd988b2728bfe0ba61bc113e3885faf363eeed960db1d507c94292a11c1d9ceb0c7fa1437a4c2800529e8f5e1602439e7f7cc039126002d5e795",
-        "dest-filename": "7cbf457ebd988b2728bfe0ba61bc113e3885faf363eeed960db1d507c94292a11c1d9ceb0c7fa1437a4c2800529e8f5e1602439e7f7cc039126002d5e795",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/01/2d"
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
+        "sha512": "ffc45f827b385c3f573925e5cd40dea46f0f5fe015587962625524148dcadc607ab6a6dd8d8a9d85c6f804a45dec2d018594a8682c61bfc913701adc6563fec6",
+        "dest-filename": "5f827b385c3f573925e5cd40dea46f0f5fe015587962625524148dcadc607ab6a6dd8d8a9d85c6f804a45dec2d018594a8682c61bfc913701adc6563fec6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/c4"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-        "sha512": "333d63c6a9bf91f80a91cfca2c70b9a88ba332f9e76ab0fdadad5c11caeceeab214d44a4b0f8a11ab587546e7ea2c00843af39efb669c30ed219aa66cd2b7837",
-        "dest-filename": "63c6a9bf91f80a91cfca2c70b9a88ba332f9e76ab0fdadad5c11caeceeab214d44a4b0f8a11ab587546e7ea2c00843af39efb669c30ed219aa66cd2b7837",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/33/3d"
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
+        "sha512": "1884e90fc74af42fabfb9c914ff50a553dfa87f0d02ce1ddc06570c281e27659c0d7af280f7bb103cefc5e5a1779b2b8525de00c1048bc474bee0a3d802505cd",
+        "dest-filename": "e90fc74af42fabfb9c914ff50a553dfa87f0d02ce1ddc06570c281e27659c0d7af280f7bb103cefc5e5a1779b2b8525de00c1048bc474bee0a3d802505cd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/84"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-        "sha512": "41b111123749788ade2006dd1b684b535c979b5baef8b4ddce8ab5282a381b8a4538b96f22ca419b7e90ad039aafd2c576e6afa165f69ac345000018f63e010e",
-        "dest-filename": "11123749788ade2006dd1b684b535c979b5baef8b4ddce8ab5282a381b8a4538b96f22ca419b7e90ad039aafd2c576e6afa165f69ac345000018f63e010e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/b1"
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
+        "sha512": "89e3080f4251658fd9782aec150dd8dcd947342a88853a6b25f0e0481dff96fe63259f055f786a3f25d685efa0bd2e4044c049db8d8f33e54dcff72d363fff78",
+        "dest-filename": "080f4251658fd9782aec150dd8dcd947342a88853a6b25f0e0481dff96fe63259f055f786a3f25d685efa0bd2e4044c049db8d8f33e54dcff72d363fff78",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/e3"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-        "sha512": "b09cf7cd135ee2d3b6c31bc3a47fc76098a56fafb6609c68fd935b55db4588a0ee7f35aae0998a0221f2f621a82e3015eebfd6df65606871a4937e5c51794d3a",
-        "dest-filename": "f7cd135ee2d3b6c31bc3a47fc76098a56fafb6609c68fd935b55db4588a0ee7f35aae0998a0221f2f621a82e3015eebfd6df65606871a4937e5c51794d3a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/9c"
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
+        "sha512": "5bdfff902ae1ffa8a7f6b58805d29a32db934f3363ea349e1bf85a581003a8b2daf4ff0ee584910f3803e72f500689380189734ba0111e27c06fbe55e86ebbd1",
+        "dest-filename": "ff902ae1ffa8a7f6b58805d29a32db934f3363ea349e1bf85a581003a8b2daf4ff0ee584910f3803e72f500689380189734ba0111e27c06fbe55e86ebbd1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5b/df"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-        "sha512": "cfd375d05043d03092d9d9920010c16f94cb032175ff27556fe378a62f3c4f8e5e7d0ff0e2886bfc5fd06029310cf9e4864a7a008a48710290f05d0036803624",
-        "dest-filename": "75d05043d03092d9d9920010c16f94cb032175ff27556fe378a62f3c4f8e5e7d0ff0e2886bfc5fd06029310cf9e4864a7a008a48710290f05d0036803624",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/d3"
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
+        "sha512": "548515e33f060fcaed49531f023d5a5c56a1b22ffeb5ca175cd6265e0cc848bf8a077f35bdb49335d7991c71c862a1725dca0486ef67e5c4fed39b51bf5deb97",
+        "dest-filename": "15e33f060fcaed49531f023d5a5c56a1b22ffeb5ca175cd6265e0cc848bf8a077f35bdb49335d7991c71c862a1725dca0486ef67e5c4fed39b51bf5deb97",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/85"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-        "sha512": "a50772008674056202e46caf5459f96b00e23b5e13913ff5f454e615c3dd0de73de0a275b9972616cdb5168f1ab8c5f30f84edf9d897bb52d6d601eeb3d7e115",
-        "dest-filename": "72008674056202e46caf5459f96b00e23b5e13913ff5f454e615c3dd0de73de0a275b9972616cdb5168f1ab8c5f30f84edf9d897bb52d6d601eeb3d7e115",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/07"
+        "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
+        "sha512": "978adf8a225137bb13348fff7dfeb9cc9f73f14fa4eb37028342c02d4e62116cd8f9ad66559f22582d64e44b0d293859ed7090e985adb19f045989bbaf5504b2",
+        "dest-filename": "df8a225137bb13348fff7dfeb9cc9f73f14fa4eb37028342c02d4e62116cd8f9ad66559f22582d64e44b0d293859ed7090e985adb19f045989bbaf5504b2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/8a"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-        "sha512": "84f951591e1e2030c4722f79dd123504b662b608b9baa72c8ca331c187e68b82dcc325a8d887113fe9538559ca8cdb64f74a4b4bc9ca76ba1760ea96f90407fb",
-        "dest-filename": "51591e1e2030c4722f79dd123504b662b608b9baa72c8ca331c187e68b82dcc325a8d887113fe9538559ca8cdb64f74a4b4bc9ca76ba1760ea96f90407fb",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/84/f9"
+        "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
+        "sha512": "5346c4b8038bbcefc35857728131d663c0b4ebb157cfe51bcca8316215c2d1f0e27856b490322b6b514086c00045125bbc4caca3c680aaf3dd371cd6b92b419c",
+        "dest-filename": "c4b8038bbcefc35857728131d663c0b4ebb157cfe51bcca8316215c2d1f0e27856b490322b6b514086c00045125bbc4caca3c680aaf3dd371cd6b92b419c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/53/46"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-        "sha512": "d61056c78394244d9c69bfbe69567ba4e6c3eacf832b898f1a97a6b6700e441bdbe65fe0e71146934bdcd0f8d292b0ecd176978fdcb2a1bdddd785eabe743883",
-        "dest-filename": "56c78394244d9c69bfbe69567ba4e6c3eacf832b898f1a97a6b6700e441bdbe65fe0e71146934bdcd0f8d292b0ecd176978fdcb2a1bdddd785eabe743883",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/10"
+        "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
+        "sha512": "373750fd7c2eeaf3d27ff1a476644db0e7c87921a787b9aeba776c588b6606c56932834f56933ad6a373015637a59d60973cc0c4b478d14c98336dde6830db61",
+        "dest-filename": "50fd7c2eeaf3d27ff1a476644db0e7c87921a787b9aeba776c588b6606c56932834f56933ad6a373015637a59d60973cc0c4b478d14c98336dde6830db61",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/37"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-        "sha512": "ea6d2c7d07f17d07f2d6a46e79c3242657f5708cd33a0c9a7976a255a6a48bcfeff9607e53885cea2935e595ba4c096546583f5ae417c568f58f1e82f9d7f2df",
-        "dest-filename": "2c7d07f17d07f2d6a46e79c3242657f5708cd33a0c9a7976a255a6a48bcfeff9607e53885cea2935e595ba4c096546583f5ae417c568f58f1e82f9d7f2df",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/6d"
+        "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
+        "sha512": "ef3970f29dc802972c37b985c343b56753f2124e8f94a32ed7cae82267e5de24074e7affc807d8bfab388573e275b0e8236434a56fb9c5ea0ce1e4c20b451dad",
+        "dest-filename": "70f29dc802972c37b985c343b56753f2124e8f94a32ed7cae82267e5de24074e7affc807d8bfab388573e275b0e8236434a56fb9c5ea0ce1e4c20b451dad",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/39"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-        "sha512": "c5b6ce75f9f4e85b5c27d7744a1c71bd29f6894b0677f9603c83b657755920f0db11a223d7fde70417b5030b8464a5d55e4326a6be8b50080c90b0ffe03d8f3c",
-        "dest-filename": "ce75f9f4e85b5c27d7744a1c71bd29f6894b0677f9603c83b657755920f0db11a223d7fde70417b5030b8464a5d55e4326a6be8b50080c90b0ffe03d8f3c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/b6"
+        "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
+        "sha512": "7068f9c258be1be9e4550759a37fbb143282db9521e195703802ba034e87b2f82bf16a8106e3b2ff5b3e3d411dffa25efaf8df9bab2d5f492689be5bfced9893",
+        "dest-filename": "f9c258be1be9e4550759a37fbb143282db9521e195703802ba034e87b2f82bf16a8106e3b2ff5b3e3d411dffa25efaf8df9bab2d5f492689be5bfced9893",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/68"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-        "sha512": "7d682a47cb8d6c243f186bf4ca1cedb63eac53ff59e7f4affd5194dc5e4eb972ba27a4a5ae238d2ab43bb4d97006b2595d1624e63521b96bc5ec66331a0b8165",
-        "dest-filename": "2a47cb8d6c243f186bf4ca1cedb63eac53ff59e7f4affd5194dc5e4eb972ba27a4a5ae238d2ab43bb4d97006b2595d1624e63521b96bc5ec66331a0b8165",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7d/68"
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
+        "sha512": "cf71ff1d823d30cd074efde1419f357fe00a6fec84a0246551bcb517cd2f6d0e5777310cc98ffd88d9409a1aa204ac383095f07e0b21ec444610e86b3359e230",
+        "dest-filename": "ff1d823d30cd074efde1419f357fe00a6fec84a0246551bcb517cd2f6d0e5777310cc98ffd88d9409a1aa204ac383095f07e0b21ec444610e86b3359e230",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/71"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-        "sha512": "682c2545d48d30dc64186a906a3314cdaeae5f347f5347489754262e33ed45b2cec771b2de8b5f16efd58c04f2e32433a3dc850c64f1603a3515f003f68443d8",
-        "dest-filename": "2545d48d30dc64186a906a3314cdaeae5f347f5347489754262e33ed45b2cec771b2de8b5f16efd58c04f2e32433a3dc850c64f1603a3515f003f68443d8",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/2c"
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
+        "sha512": "c330b6e03c40be4f049b4d589955f28e5f7a32bf9e7133f23ae00302f8c683e7f20691a6c6672bd84e6db5fec89bc0f4b17662869c733b58acbacf0c7633025d",
+        "dest-filename": "b6e03c40be4f049b4d589955f28e5f7a32bf9e7133f23ae00302f8c683e7f20691a6c6672bd84e6db5fec89bc0f4b17662869c733b58acbacf0c7633025d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c3/30"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-        "sha512": "9f2bec05c731340b0d633da3545630106b914689aa675e3d037f521d6938855d235b128cd218c13e6dc099dc5c6c78852db052c06e926e921c51b5e38321027c",
-        "dest-filename": "ec05c731340b0d633da3545630106b914689aa675e3d037f521d6938855d235b128cd218c13e6dc099dc5c6c78852db052c06e926e921c51b5e38321027c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/2b"
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
+        "sha512": "d5843cc9b1a2db2217b30bba78dcc9b2b608185a67973116465ea247980c826b2b47415c3685759bd93db1cdcfb8fe6b5012ec84e67295cf67a92832988f9362",
+        "dest-filename": "3cc9b1a2db2217b30bba78dcc9b2b608185a67973116465ea247980c826b2b47415c3685759bd93db1cdcfb8fe6b5012ec84e67295cf67a92832988f9362",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/84"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-        "sha512": "435298d6225a7ccf945fa08510bf85e07453832826116e7af1832a0c0e5457dec0b994a6db56fb49722b4490f05d63f3afc306afbe5f5193d5ebb15db4c1e51c",
-        "dest-filename": "98d6225a7ccf945fa08510bf85e07453832826116e7af1832a0c0e5457dec0b994a6db56fb49722b4490f05d63f3afc306afbe5f5193d5ebb15db4c1e51c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/52"
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
+        "sha512": "e59f83ccb0abab9c2653b44368c0ded835573119b6b530ef5f6294d78249541376093feaa2fed7562c7ce50a09a8796da6f00e65401cde7754e7a1d2316aeff2",
+        "dest-filename": "83ccb0abab9c2653b44368c0ded835573119b6b530ef5f6294d78249541376093feaa2fed7562c7ce50a09a8796da6f00e65401cde7754e7a1d2316aeff2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/9f"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-        "sha512": "5b57b218d8ba77ef243a6648c22fc40e3acbf67c50210d0c886a9efc059cebe21a1e5a311d21a879180344a1c52124e12e6b1ec19e671c5bc615674162580a3e",
-        "dest-filename": "b218d8ba77ef243a6648c22fc40e3acbf67c50210d0c886a9efc059cebe21a1e5a311d21a879180344a1c52124e12e6b1ec19e671c5bc615674162580a3e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5b/57"
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
+        "sha512": "43bdc437321d3c5e636a9e30a8bb6c7e1f186d8499f10d309f1a653a56543b2672ec1e19296f035c65a04c266617c5560fb4dc8b0bf917836c45feaf62566daa",
+        "dest-filename": "c437321d3c5e636a9e30a8bb6c7e1f186d8499f10d309f1a653a56543b2672ec1e19296f035c65a04c266617c5560fb4dc8b0bf917836c45feaf62566daa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/bd"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-        "sha512": "df4cf568a2fd876da44218a59d890e44562dfb7c29ef266c1d6bacfb048a00947c26d75f23be8b27848174cb02a294d1df3fce46a56ee4bd6fb671d95958f871",
-        "dest-filename": "f568a2fd876da44218a59d890e44562dfb7c29ef266c1d6bacfb048a00947c26d75f23be8b27848174cb02a294d1df3fce46a56ee4bd6fb671d95958f871",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/4c"
+        "url": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
+        "sha512": "6a36c7ac633f5e22beb1733427311b2407a7fb413e24c419da5e11478545c2f57d244111c7ea31b60929a0abf549ebe18dabcadb3d91787937da98f392d59b1a",
+        "dest-filename": "c7ac633f5e22beb1733427311b2407a7fb413e24c419da5e11478545c2f57d244111c7ea31b60929a0abf549ebe18dabcadb3d91787937da98f392d59b1a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/36"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-        "sha512": "6888ad05c8d07b23a131322684b666b717dd39cb8d469c253cd9a514a3dc1d060f844b2cc3be429754d25c95e9324cdab9af4551eb71ff83902aaede26e9790a",
-        "dest-filename": "ad05c8d07b23a131322684b666b717dd39cb8d469c253cd9a514a3dc1d060f844b2cc3be429754d25c95e9324cdab9af4551eb71ff83902aaede26e9790a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/88"
+        "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
+        "sha512": "20f516fb2e15223b83567f8e3331dce455781ae6c8c0f9eccfab9b92f37c72e844a87f35368bc1e7721496b94190f3043f1bcd9dfefd306068cfcad9da25bc1c",
+        "dest-filename": "16fb2e15223b83567f8e3331dce455781ae6c8c0f9eccfab9b92f37c72e844a87f35368bc1e7721496b94190f3043f1bcd9dfefd306068cfcad9da25bc1c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/f5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
+        "sha512": "4485515a2963580e82755bbcce459c46618fee2451208c2f84329e9bc50c0633ea9764d73393e40d5befaf332d8f557e5853c1e0aef390818ced5cd1b4592376",
+        "dest-filename": "515a2963580e82755bbcce459c46618fee2451208c2f84329e9bc50c0633ea9764d73393e40d5befaf332d8f557e5853c1e0aef390818ced5cd1b4592376",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/85"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
+        "sha512": "d8147933c08f6e9b42d402b925b253d5f5ab1cbbde8f066274ac7750c485d1e70731afac9a18b5e9dac8ac212082482f881c0b61de67c2b14b4a5e4a868f7a45",
+        "dest-filename": "7933c08f6e9b42d402b925b253d5f5ab1cbbde8f066274ac7750c485d1e70731afac9a18b5e9dac8ac212082482f881c0b61de67c2b14b4a5e4a868f7a45",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d8/14"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
+        "sha512": "7795fa44c62fead688ca64a4f0904ffa7c6ff03400318e80e7518f82eb2a2dd2bdc01cf9c16217cb52a34dc93a1e78c4f61a89cc945d93ed69fede6ca126c2b7",
+        "dest-filename": "fa44c62fead688ca64a4f0904ffa7c6ff03400318e80e7518f82eb2a2dd2bdc01cf9c16217cb52a34dc93a1e78c4f61a89cc945d93ed69fede6ca126c2b7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/95"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.5.0.tgz",
+        "sha512": "30086e4ca96be32fc21375985f6eab6998f2f88fe44b63cb292cef7e60c21ab04b4c51ce630a9139976be17c0f817c17dcaf6b8f332be294a65161a7cec53232",
+        "dest-filename": "6e4ca96be32fc21375985f6eab6998f2f88fe44b63cb292cef7e60c21ab04b4c51ce630a9139976be17c0f817c17dcaf6b8f332be294a65161a7cec53232",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/08"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+        "sha512": "6b25451ddb59fa1b2ad6dd83cb6e300a619719ee2af46bb7b2684b6002c9aebe3bdd91f6eccb2748bf8b2949629a9e01589a8c0cc2e63e9c7f43d47738094be2",
+        "dest-filename": "451ddb59fa1b2ad6dd83cb6e300a619719ee2af46bb7b2684b6002c9aebe3bdd91f6eccb2748bf8b2949629a9e01589a8c0cc2e63e9c7f43d47738094be2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/25"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+        "sha512": "12b8924e5b79382f7fed25e445208085f4b1c684948019b7dce1fe224c1b769828aac4ac520ef2dee87e208088fd08380415abdd4da2dfd4699b271bc4cab87b",
+        "dest-filename": "924e5b79382f7fed25e445208085f4b1c684948019b7dce1fe224c1b769828aac4ac520ef2dee87e208088fd08380415abdd4da2dfd4699b271bc4cab87b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/b8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
+        "sha512": "71f3bcd95f73c71181c5c403af595f69807bc329136b46f4d2619adfa16b265ee24c57746767077c462ec5c0513ff88d8a30ac5ac12403e8f34fc846626bf7df",
+        "dest-filename": "bcd95f73c71181c5c403af595f69807bc329136b46f4d2619adfa16b265ee24c57746767077c462ec5c0513ff88d8a30ac5ac12403e8f34fc846626bf7df",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/f3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+        "sha512": "6b0d6035ac96a5d23f8d2615833379a4bd1c7f3534d864f7341a5e4ff0d76f1d7fd71ed92b114f77d6f0af3ca0c7faa2c08422275b30ff30fca98fe446f9461c",
+        "dest-filename": "6035ac96a5d23f8d2615833379a4bd1c7f3534d864f7341a5e4ff0d76f1d7fd71ed92b114f77d6f0af3ca0c7faa2c08422275b30ff30fca98fe446f9461c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/0d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+        "sha512": "801af137cf203887f747b8dae4af6c97035ac9571980ae923943919b6b81cd378811f79568884ea42b53a31dcfe91ee8da32c5c0b1532e70bb914fd119c60483",
+        "dest-filename": "f137cf203887f747b8dae4af6c97035ac9571980ae923943919b6b81cd378811f79568884ea42b53a31dcfe91ee8da32c5c0b1532e70bb914fd119c60483",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/1a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+        "sha512": "c8bfec2eba66b43685122523d68b113f84c8d8c0f3d4075d24bfa367b292aaf06e962378c6a618e7821f74df2a0fc4e86ba8358a5a298757f140d9233b1aeba5",
+        "dest-filename": "ec2eba66b43685122523d68b113f84c8d8c0f3d4075d24bfa367b292aaf06e962378c6a618e7821f74df2a0fc4e86ba8358a5a298757f140d9233b1aeba5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/bf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+        "sha512": "2abf8b3c85152b3daa931d4700c1fcab5aba6b36ea040b17254c4197f3830ee54f5f8e59f437f007cb4f8d38ba9cd67c06e3379db2710b9cc2020e5e9670544d",
+        "dest-filename": "8b3c85152b3daa931d4700c1fcab5aba6b36ea040b17254c4197f3830ee54f5f8e59f437f007cb4f8d38ba9cd67c06e3379db2710b9cc2020e5e9670544d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/bf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+        "sha512": "ab59a32285b5557e08bd2a1cbccfef6d38af78a0b893d78bada8cd12e4ac9a3ca648311ba4675db697cea0ded8180a812b7346faeaa8f226b83c34edf1bb8260",
+        "dest-filename": "a32285b5557e08bd2a1cbccfef6d38af78a0b893d78bada8cd12e4ac9a3ca648311ba4675db697cea0ded8180a812b7346faeaa8f226b83c34edf1bb8260",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ab/59"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/markdown/-/markdown-7.5.1.tgz",
+        "sha512": "47cb997a61bd74a4dbaeefc34113db95b2725e939bc0ace8f2bbf5298186b8f50fb633382d705833dab90886400a89b366ea70b37b566c3c1a9b9005a4f2f225",
+        "dest-filename": "997a61bd74a4dbaeefc34113db95b2725e939bc0ace8f2bbf5298186b8f50fb633382d705833dab90886400a89b366ea70b37b566c3c1a9b9005a4f2f225",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/cb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+        "sha512": "56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738",
+        "dest-filename": "0e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/d0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+        "sha512": "e37feab6b0d4a24afb2c9aa8176737f91227bbfb78cdfae961da120df632860e76af02d5e939cebdd1b87d79bb224481df012b91c9894bd88486356d3921238c",
+        "dest-filename": "eab6b0d4a24afb2c9aa8176737f91227bbfb78cdfae961da120df632860e76af02d5e939cebdd1b87d79bb224481df012b91c9894bd88486356d3921238c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/7f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+        "sha512": "e43c90e3ed49114cde8de2b524620272275ec9f51b1a2c604bd8cd81ec799ea916f9c63b59987106282689e379427c3d668b123550bd2902b26fe194686c8a50",
+        "dest-filename": "90e3ed49114cde8de2b524620272275ec9f51b1a2c604bd8cd81ec799ea916f9c63b59987106282689e379427c3d668b123550bd2902b26fe194686c8a50",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/3c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+        "sha512": "ff3531fb23ac22b1b8638dc4876a5e0de282c6546dfe0113e9a1df68aa6eab6ebba977580c55625477cc68bcb28193a79749065b114882c072f1016e4cb51711",
+        "dest-filename": "31fb23ac22b1b8638dc4876a5e0de282c6546dfe0113e9a1df68aa6eab6ebba977580c55625477cc68bcb28193a79749065b114882c072f1016e4cb51711",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/35"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+        "sha512": "6f1bde57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c",
+        "dest-filename": "de57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/1b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+        "sha512": "6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285",
+        "dest-filename": "13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/5d"
     },
     {
         "type": "file",
@@ -279,143 +440,150 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
-        "sha512": "49e0e738ed1393b3a48aae836d79a604e0e03806fd769f608e5a61a244d4c66b7c53796220fd59b28cc16a11faf63fd126ff917ece88c142874e041827f1c103",
-        "dest-filename": "e738ed1393b3a48aae836d79a604e0e03806fd769f608e5a61a244d4c66b7c53796220fd59b28cc16a11faf63fd126ff917ece88c142874e041827f1c103",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/e0"
+        "url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz",
+        "sha512": "16ae83256f816f98da584ebdfea384d03d5350df7eeae5a109e669767481935e298cb702591ed0f27e3d3d348f1dacccdfb26aaec76912d857cb6c67ea359688",
+        "dest-filename": "83256f816f98da584ebdfea384d03d5350df7eeae5a109e669767481935e298cb702591ed0f27e3d3d348f1dacccdfb26aaec76912d857cb6c67ea359688",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/ae"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.99.0.tgz",
-        "sha512": "f22139ff838ad122c7a96cd1c52bc8d608c53e6207ebbd7cb3c8b092e728f79ac166c099207abee70cb8958b004b19c7fbc14e85b1a776252b730b151b98b6cf",
-        "dest-filename": "39ff838ad122c7a96cd1c52bc8d608c53e6207ebbd7cb3c8b092e728f79ac166c099207abee70cb8958b004b19c7fbc14e85b1a776252b730b151b98b6cf",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/21"
+        "url": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.101.0.tgz",
+        "sha512": "b77aa97d5648a9288b4392aab7f302e067bf582386aeb71a8007734dc0da820ba98e21b1531e27245dafeb05025d64b35879f936ced72efd777c2244c0238445",
+        "dest-filename": "a97d5648a9288b4392aab7f302e067bf582386aeb71a8007734dc0da820ba98e21b1531e27245dafeb05025d64b35879f936ced72efd777c2244c0238445",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/7a"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@oxc-project/types/-/types-0.99.0.tgz",
-        "sha512": "2cb0c485707b8359b927ec2845281f2ac14f4b72e147dc51853788a04066e56ae4c0cc67e9e6742ddd1cd0ae5e1c1e7b0a1657e88dee4a698b8d9f2972395173",
-        "dest-filename": "c485707b8359b927ec2845281f2ac14f4b72e147dc51853788a04066e56ae4c0cc67e9e6742ddd1cd0ae5e1c1e7b0a1657e88dee4a698b8d9f2972395173",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/b0"
+        "url": "https://registry.npmjs.org/@oxc-project/types/-/types-0.101.0.tgz",
+        "sha512": "9ee161aa5533257fa05483cf7ee13ac6eadde25493de675c58e8722bfad93b407d5d630a9bbf52baccc84049d232698386ad430bc59655819577ee85f77a3581",
+        "dest-filename": "61aa5533257fa05483cf7ee13ac6eadde25493de675c58e8722bfad93b407d5d630a9bbf52baccc84049d232698386ad430bc59655819577ee85f77a3581",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9e/e1"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.52.tgz",
-        "sha512": "301188832b229993ea4c370b5c8fa2f55bde8a390fe42dc4027704a205e1a9f6b1e985e3d53af62d8dc356e10e3088d67cc3cc86d4123eea787d24c09a08ea23",
-        "dest-filename": "88832b229993ea4c370b5c8fa2f55bde8a390fe42dc4027704a205e1a9f6b1e985e3d53af62d8dc356e10e3088d67cc3cc86d4123eea787d24c09a08ea23",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/11"
+        "url": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+        "sha512": "40da97c9f552db09bd870792603d8eec5d06d3abaeae3f6467de9345013963d854efeb60759c0891b00a73939ccb51f1118da4b8341ae9c435591b3f3b92c528",
+        "dest-filename": "97c9f552db09bd870792603d8eec5d06d3abaeae3f6467de9345013963d854efeb60759c0891b00a73939ccb51f1118da4b8341ae9c435591b3f3b92c528",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/40/da"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.52.tgz",
-        "sha512": "32629ea0b9cabb577d8faaf5f4af01fa9ac99c867bbbecd0fb3190dd81d71a7af8d6bcc4ddea902e8be592fa199d1a310c63c0e29b34a468b05f2e98137949ca",
-        "dest-filename": "9ea0b9cabb577d8faaf5f4af01fa9ac99c867bbbecd0fb3190dd81d71a7af8d6bcc4ddea902e8be592fa199d1a310c63c0e29b34a468b05f2e98137949ca",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/62"
+        "url": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.53.tgz",
+        "sha512": "3a4f55f28ee8e987d27534d803fb871f7d2bdd8b4ec4b0fa1b7c2287f53d0ced2e701045abc58fb7f0ec954e773a07ed78b447213667cbd37fa8253131ff648d",
+        "dest-filename": "55f28ee8e987d27534d803fb871f7d2bdd8b4ec4b0fa1b7c2287f53d0ced2e701045abc58fb7f0ec954e773a07ed78b447213667cbd37fa8253131ff648d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/4f"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.52.tgz",
-        "sha512": "aa91de76f4019888d3f337678cdde758f476aa343226db5b5e788210a29d1de01b646f47c8d3c1533405ec06591b0992f5ca1028bfa15a0f45856ce1d9d67620",
-        "dest-filename": "de76f4019888d3f337678cdde758f476aa343226db5b5e788210a29d1de01b646f47c8d3c1533405ec06591b0992f5ca1028bfa15a0f45856ce1d9d67620",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/91"
+        "url": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.53.tgz",
+        "sha512": "c88b0aa8ccf40ad46755aeb1dcf6be9b34e286be13cbe67a1df3db67b4556e4d54c67728e3e0949fb41b9bfe52068975243ffb9ef63cae9840832022ecb8fa56",
+        "dest-filename": "0aa8ccf40ad46755aeb1dcf6be9b34e286be13cbe67a1df3db67b4556e4d54c67728e3e0949fb41b9bfe52068975243ffb9ef63cae9840832022ecb8fa56",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/8b"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.52.tgz",
-        "sha512": "743a7b59b3daa63fcd556d0b4a21ff08bc0c8662f0c0a6f747b9a1da4597f905bce57d431959c81322a1f4f98d26307ffacb86d5d27281db5d34f5572b587296",
-        "dest-filename": "7b59b3daa63fcd556d0b4a21ff08bc0c8662f0c0a6f747b9a1da4597f905bce57d431959c81322a1f4f98d26307ffacb86d5d27281db5d34f5572b587296",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/3a"
+        "url": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.53.tgz",
+        "sha512": "1935defa6c6c08652724e14c85f19699e7cfed0f53a5852c787be1021af6d6709381d4bc8cfb2f8ab6f4b49c0cde5374feefdc83b6e914d6b5e9f42b8caac28d",
+        "dest-filename": "defa6c6c08652724e14c85f19699e7cfed0f53a5852c787be1021af6d6709381d4bc8cfb2f8ab6f4b49c0cde5374feefdc83b6e914d6b5e9f42b8caac28d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/35"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.52.tgz",
-        "sha512": "f5ee25eafcb9a8d4a58833ea35f47a0a404e031e8f1fb8835783898842736a36a31ab572f2073f20a28952ca04e761bcb9df0c5faaf73cc97decd7f080ecc1ee",
-        "dest-filename": "25eafcb9a8d4a58833ea35f47a0a404e031e8f1fb8835783898842736a36a31ab572f2073f20a28952ca04e761bcb9df0c5faaf73cc97decd7f080ecc1ee",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/ee"
+        "url": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.53.tgz",
+        "sha512": "f539a9edb06f2aac8390c70be1ed3cf691f746c8c3dd252e9e08e6a96b7284d3b1a10321d1f4a620d4f2615f0a5ed13e264c5830f5af9c4b7efe67e9542924f3",
+        "dest-filename": "a9edb06f2aac8390c70be1ed3cf691f746c8c3dd252e9e08e6a96b7284d3b1a10321d1f4a620d4f2615f0a5ed13e264c5830f5af9c4b7efe67e9542924f3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/39"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.52.tgz",
-        "sha512": "578f280d1f387de454d8a46ece900ba79f7852a971dbbfb316c4faf818137173adbbb756cb7e742751b6f327680b0281fa8c70b113f1d9eeda7909e67776096d",
-        "dest-filename": "280d1f387de454d8a46ece900ba79f7852a971dbbfb316c4faf818137173adbbb756cb7e742751b6f327680b0281fa8c70b113f1d9eeda7909e67776096d",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/8f"
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.53.tgz",
+        "sha512": "6b5cb97e20748a8beecdd6e35316bbf9972f82ffa64e6946182e17c9d548b32978f1ea3181a62403797dd3bf61c93ca1102b0fabe99baf481542c154d7538901",
+        "dest-filename": "b97e20748a8beecdd6e35316bbf9972f82ffa64e6946182e17c9d548b32978f1ea3181a62403797dd3bf61c93ca1102b0fabe99baf481542c154d7538901",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/5c"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.52.tgz",
-        "sha512": "10d2e6490096a9203ff98378e55d85a9321e9a0ed0b296a24e3966df6ede50031e38b76a992395572ad07b124635343933cb036028150228362a4d351a09aa6b",
-        "dest-filename": "e6490096a9203ff98378e55d85a9321e9a0ed0b296a24e3966df6ede50031e38b76a992395572ad07b124635343933cb036028150228362a4d351a09aa6b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/d2"
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.53.tgz",
+        "sha512": "6e92065fea2ff4f849615fb01cd5e5f6bceae05d10bc82e25119f4cb4a1ea5b431fbbb2d990b0a0340e13c6c2685fbc5f39eb0abe81b33c2fdd9201afc205c2e",
+        "dest-filename": "065fea2ff4f849615fb01cd5e5f6bceae05d10bc82e25119f4cb4a1ea5b431fbbb2d990b0a0340e13c6c2685fbc5f39eb0abe81b33c2fdd9201afc205c2e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/92"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.52.tgz",
-        "sha512": "9256a195bd8420596d494b9b9ff54b8ee737ab1a7513bb61f2e91ac8f7dd91c2afbd8710e6b273b60c7c26c252b80295ccab4d4ea5063a1cb83a7ef506ec95f2",
-        "dest-filename": "a195bd8420596d494b9b9ff54b8ee737ab1a7513bb61f2e91ac8f7dd91c2afbd8710e6b273b60c7c26c252b80295ccab4d4ea5063a1cb83a7ef506ec95f2",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/56"
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.53.tgz",
+        "sha512": "6c67b910107c1558c7051d6638b38f1058352e9dffffb81ea96914e4d221c5efb21f45bc155ad0e9645839aa784944ca764943fdd0b8a8f2d112430c43ce7914",
+        "dest-filename": "b910107c1558c7051d6638b38f1058352e9dffffb81ea96914e4d221c5efb21f45bc155ad0e9645839aa784944ca764943fdd0b8a8f2d112430c43ce7914",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/67"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.52.tgz",
-        "sha512": "52e03e26a40882ab6480637673f010e708bc33a9891eb6a1cffc1c88434f4de23acc421b6cb1a8b61e5737eb107b6a490de8c45687cdf5a380a7491a6b3c2756",
-        "dest-filename": "3e26a40882ab6480637673f010e708bc33a9891eb6a1cffc1c88434f4de23acc421b6cb1a8b61e5737eb107b6a490de8c45687cdf5a380a7491a6b3c2756",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/e0"
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.53.tgz",
+        "sha512": "a8bfbadd629542cd4232f15e7653edd14f4f8842893802ff6ec1cc2940d2e95a7643e600bff40b3eef2b72f91f20cbd0d053d4d962f4697e1e5b017a7bf1809c",
+        "dest-filename": "badd629542cd4232f15e7653edd14f4f8842893802ff6ec1cc2940d2e95a7643e600bff40b3eef2b72f91f20cbd0d053d4d962f4697e1e5b017a7bf1809c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/bf"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.52.tgz",
-        "sha512": "d413505bcbb8ae8f1bb0dd7eb602843498aa9af73e59fb9a5215f330898e552330dbca6404a75f66d5f6a893c00d5ded7abc7ebcd26d96c81219e6f7f96e898b",
-        "dest-filename": "505bcbb8ae8f1bb0dd7eb602843498aa9af73e59fb9a5215f330898e552330dbca6404a75f66d5f6a893c00d5ded7abc7ebcd26d96c81219e6f7f96e898b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/13"
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.53.tgz",
+        "sha512": "54697d2481a3a098771fc31bfbbc6756a3836a3066add38e6fd97159775c9b1c88fb38c1dacbb1ebd6ebd216490d3c8b25fbc1a189b8dfdccf00261b0a31919b",
+        "dest-filename": "7d2481a3a098771fc31bfbbc6756a3836a3066add38e6fd97159775c9b1c88fb38c1dacbb1ebd6ebd216490d3c8b25fbc1a189b8dfdccf00261b0a31919b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/69"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.52.tgz",
-        "sha512": "2bfa7b725842a89390a571b292b15a057d83a7d0145480c719cf8fb45181c20ed5fa6bc14effedb26dcb0b7694987d361f6cb7833e32fa751343430ba687c412",
-        "dest-filename": "7b725842a89390a571b292b15a057d83a7d0145480c719cf8fb45181c20ed5fa6bc14effedb26dcb0b7694987d361f6cb7833e32fa751343430ba687c412",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2b/fa"
+        "url": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.53.tgz",
+        "sha512": "078888b1eac95ee4a7373039c412c55088d37e1372eddf6cab81543106371a1416195852d91596cf30e791253a314b7bfda1d4adea7409d41f5d4248f43dd6ec",
+        "dest-filename": "88b1eac95ee4a7373039c412c55088d37e1372eddf6cab81543106371a1416195852d91596cf30e791253a314b7bfda1d4adea7409d41f5d4248f43dd6ec",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/07/88"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.52.tgz",
-        "sha512": "6b81245c1b67618b0a8a98d2ed03a11013386d4e48951f4dd6153e25c54455eb9389ab2523285654ab2f7fb2b6624407c95009fbbfc0f41b6b1aa39115c4e09e",
-        "dest-filename": "245c1b67618b0a8a98d2ed03a11013386d4e48951f4dd6153e25c54455eb9389ab2523285654ab2f7fb2b6624407c95009fbbfc0f41b6b1aa39115c4e09e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/81"
+        "url": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.53.tgz",
+        "sha512": "0548c0120a400442578a51aafc13e1ee3794dd6009e68d79735644807683592cf72c1f3cd4b4199db3491e652233877525058c618c91d58e3dd080478b614f26",
+        "dest-filename": "c0120a400442578a51aafc13e1ee3794dd6009e68d79735644807683592cf72c1f3cd4b4199db3491e652233877525058c618c91d58e3dd080478b614f26",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/48"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.52.tgz",
-        "sha512": "e595dc6327781b13c0e907db1ab35c4239a36ee2c6bdfcfaef6f2964cb10bc61c8fb4e8b4f4e8ce933ed5ef16f2e05ed7b173e3aabc57b5c80217254d60a1bff",
-        "dest-filename": "dc6327781b13c0e907db1ab35c4239a36ee2c6bdfcfaef6f2964cb10bc61c8fb4e8b4f4e8ce933ed5ef16f2e05ed7b173e3aabc57b5c80217254d60a1bff",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/95"
+        "url": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.53.tgz",
+        "sha512": "b36eee53bb690964a31c19f1c955c7b77accad0749ab930736fdc1cec7b0088ae8230dc32458cc1f577308f3cc505c67875af9d8d7fd209fde5a9e8b0e8c8673",
+        "dest-filename": "ee53bb690964a31c19f1c955c7b77accad0749ab930736fdc1cec7b0088ae8230dc32458cc1f577308f3cc505c67875af9d8d7fd209fde5a9e8b0e8c8673",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b3/6e"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.52.tgz",
-        "sha512": "b73a674505c9ad2cdbf19f6c9bded40f7718d2da0a3889b1fb144ab032d7e331da0254575a1ee36da28178f25710dee0370ecd9b4dcf04dc2985db40f0a49461",
-        "dest-filename": "674505c9ad2cdbf19f6c9bded40f7718d2da0a3889b1fb144ab032d7e331da0254575a1ee36da28178f25710dee0370ecd9b4dcf04dc2985db40f0a49461",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/3a"
+        "url": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.53.tgz",
+        "sha512": "72358bfd448f2758347a7da1b5be2cb0c8c8c9c737e91bdd400c755a55e74ba0e950bb308944d55cf0deb1389f48a612cafc76e04d18a909049b42bf33667f00",
+        "dest-filename": "8bfd448f2758347a7da1b5be2cb0c8c8c9c737e91bdd400c755a55e74ba0e950bb308944d55cf0deb1389f48a612cafc76e04d18a909049b42bf33667f00",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/35"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.50.tgz",
-        "sha512": "e5eefac1089055e2f52023995548382d2395620f63ca11828a7fa2718a3386c53333e7c713b91d762d5b7621348f056a4df9236dade35056c49280bd5a476fc8",
-        "dest-filename": "fac1089055e2f52023995548382d2395620f63ca11828a7fa2718a3386c53333e7c713b91d762d5b7621348f056a4df9236dade35056c49280bd5a476fc8",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/ee"
+        "url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
+        "sha512": "bc435194553861baf056a34367b7cbbf2f89475091932af4d63852883a44d6eea9cb738ccd07f3b505368f1ca45b700b3713b891296a203798c83d18f5171079",
+        "dest-filename": "5194553861baf056a34367b7cbbf2f89475091932af4d63852883a44d6eea9cb738ccd07f3b505368f1ca45b700b3713b891296a203798c83d18f5171079",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/43"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.52.tgz",
-        "sha512": "fcbd21b4b2596da6452f583d38739b953c5b09820679f12b263b583b0825f59a8dc76ecfdcbd120df8e184722cb37da0bb9356827c6e4f66b61e79efe9018728",
-        "dest-filename": "21b4b2596da6452f583d38739b953c5b09820679f12b263b583b0825f59a8dc76ecfdcbd120df8e184722cb37da0bb9356827c6e4f66b61e79efe9018728",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/bd"
+        "url": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+        "sha512": "4de85e632d082f304423f08ee7908feb324249d496791b469c7cbc53c7564941f823af22a93b32ec790c92d478c5a91385cf63a2d90f4145d3e084dd6d5edc1c",
+        "dest-filename": "5e632d082f304423f08ee7908feb324249d496791b469c7cbc53c7564941f823af22a93b32ec790c92d478c5a91385cf63a2d90f4145d3e084dd6d5edc1c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/e8"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.0.tgz",
-        "sha512": "a83e6d32387bbadc0193dff93eb4c0fda1abde2e50689fcc96dee9f0d8a5438e5681b89f50d3f2296b00eb7890f187d0aba47c6a331aa54fbf43c9cc70f44b37",
-        "dest-filename": "6d32387bbadc0193dff93eb4c0fda1abde2e50689fcc96dee9f0d8a5438e5681b89f50d3f2296b00eb7890f187d0aba47c6a331aa54fbf43c9cc70f44b37",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/3e"
+        "url": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.6.1.tgz",
+        "sha512": "242b3e32aa177d7ad13c66c69a1a3fcc64bf8cc727de278a97f03c6089aa89befa0bc923819c2ae6e505cdcdf494990cbdc721b919fafeff080292f1962dc9cb",
+        "dest-filename": "3e32aa177d7ad13c66c69a1a3fcc64bf8cc727de278a97f03c6089aa89befa0bc923819c2ae6e505cdcdf494990cbdc721b919fafeff080292f1962dc9cb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/2b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz",
+        "sha512": "2069613fa122be35c77a96c189ceb5f063a68967b851126221e645941ef1ddccccd320c71d8be21f55efa22bf815e7dd910b67eafed3bb058245f3867675541b",
+        "dest-filename": "613fa122be35c77a96c189ceb5f063a68967b851126221e645941ef1ddccccd320c71d8be21f55efa22bf815e7dd910b67eafed3bb058245f3867675541b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/69"
     },
     {
         "type": "file",
@@ -433,38 +601,157 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-        "sha512": "18d59c5134418084490f9ce3f93ab47ca389e5765a8c8881ae8385d32be3d9b494d56bcd7584bf767f54c70b2e8c65b8257d3a7671f28d5db2f6b45ac9b1f489",
-        "dest-filename": "9c5134418084490f9ce3f93ab47ca389e5765a8c8881ae8385d32be3d9b494d56bcd7584bf767f54c70b2e8c65b8257d3a7671f28d5db2f6b45ac9b1f489",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/d5"
+        "url": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+        "sha512": "bc80a159d546dcb1b548cc44bc8fc02be15626d865aea953bbb7dbae5cb04e491a38dc24fd40066942d74657fcbe4cc504b566d3390c742aae84be5a3a38573d",
+        "dest-filename": "a159d546dcb1b548cc44bc8fc02be15626d865aea953bbb7dbae5cb04e491a38dc24fd40066942d74657fcbe4cc504b566d3390c742aae84be5a3a38573d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/80"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.2.tgz",
-        "sha512": "8879b057741c5461af482d411b96d9e33ea2c1ad523a900f5a69e3384adde1291efa566e6b92bd4ed015771d203010a5276f0356209b4a6662b63599b163b72c",
-        "dest-filename": "b057741c5461af482d411b96d9e33ea2c1ad523a900f5a69e3384adde1291efa566e6b92bd4ed015771d203010a5276f0356209b4a6662b63599b163b72c",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/79"
+        "url": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+        "sha512": "7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb",
+        "dest-filename": "f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/61"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz",
-        "sha512": "84411de444ffa129810baa62d63e8d68d6115a80220e120d6d3f2b9b0b4836e811dfd96844e4a5b9f19d60c17d4da2867f3f95886b3521d8b7980867b8f72819",
-        "dest-filename": "1de444ffa129810baa62d63e8d68d6115a80220e120d6d3f2b9b0b4836e811dfd96844e4a5b9f19d60c17d4da2867f3f95886b3521d8b7980867b8f72819",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/84/41"
+        "url": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+        "sha512": "e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c",
+        "dest-filename": "cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/e7"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.23.tgz",
-        "sha512": "67551cf08079ecb9ba93baba2880eefe9f895ad7f7c6c5c9a805ffe6bd7c858393a49c819f4297511f284c9e1615839c0f3582f67dc87e51a01e8c31e94eb3f5",
-        "dest-filename": "1cf08079ecb9ba93baba2880eefe9f895ad7f7c6c5c9a805ffe6bd7c858393a49c819f4297511f284c9e1615839c0f3582f67dc87e51a01e8c31e94eb3f5",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/55"
+        "url": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+        "sha512": "90668d6cf87593b005ce0a6e77f80c76f226e71b840b291147e26758a427a3d4c05d56ba5885421933ef6067a42032f8bb009941261b53134149bd5a528efda0",
+        "dest-filename": "8d6cf87593b005ce0a6e77f80c76f226e71b840b291147e26758a427a3d4c05d56ba5885421933ef6067a42032f8bb009941261b53134149bd5a528efda0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/66"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.23.tgz",
-        "sha512": "940079cc98215b154fa9f712b6600fd59a9069c3297bdd14acfe512776ab0f2ae1cb8682510aa6c4f3cb0763d60caba0bf29663b8d658caeef67eb7a20d3136a",
-        "dest-filename": "79cc98215b154fa9f712b6600fd59a9069c3297bdd14acfe512776ab0f2ae1cb8682510aa6c4f3cb0763d60caba0bf29663b8d658caeef67eb7a20d3136a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/00"
+        "url": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+        "sha512": "1ac0822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+        "dest-filename": "822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
+        "sha512": "be70d5a583cccece30ba7976ee31eb7e6c288ce18ac9ad31c8cdec1fe504e62bf9b8f4babd7ed422887a9bebd07392c606ae761c128f227ff3712655cde0c466",
+        "dest-filename": "d5a583cccece30ba7976ee31eb7e6c288ce18ac9ad31c8cdec1fe504e62bf9b8f4babd7ed422887a9bebd07392c606ae761c128f227ff3712655cde0c466",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/70"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+        "sha512": "928fe0205251bf5efb5e066c65c0709ea24de71fc689e9fca8d3a7d03e5b414ff303355ff59b7706571488baa157dcb801193419b4f7b675223cd8274d7cdcfd",
+        "dest-filename": "e0205251bf5efb5e066c65c0709ea24de71fc689e9fca8d3a7d03e5b414ff303355ff59b7706571488baa157dcb801193419b4f7b675223cd8274d7cdcfd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/8f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz",
+        "sha512": "3bb42798e5d8295b4fadf63332896b0937e47b30894bdfa58cb74a5bff830af46c737500cfeb1b1fa5dcb2fee9df4fb43b051b7967d40c0404d2fa5a6d9dd02e",
+        "dest-filename": "2798e5d8295b4fadf63332896b0937e47b30894bdfa58cb74a5bff830af46c737500cfeb1b1fa5dcb2fee9df4fb43b051b7967d40c0404d2fa5a6d9dd02e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/b4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz",
+        "sha512": "ebf726176a626a8f9feb04b152c24b663724ece42c63246d70e652d3693b5c8352365cfddefe9e98cf16bad0d04979eba06db1c18944547248f9c3c0ec23ccdd",
+        "dest-filename": "26176a626a8f9feb04b152c24b663724ece42c63246d70e652d3693b5c8352365cfddefe9e98cf16bad0d04979eba06db1c18944547248f9c3c0ec23ccdd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/f7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz",
+        "sha512": "0a0fe741c2f505ca138a3116cb1e269150b9eabf1d8f8e1b143bc17728227ee4b6d1fdce6421e615b8c5df80cf4a2d3b930945bea7efff138b9c9e43aaec5219",
+        "dest-filename": "e741c2f505ca138a3116cb1e269150b9eabf1d8f8e1b143bc17728227ee4b6d1fdce6421e615b8c5df80cf4a2d3b930945bea7efff138b9c9e43aaec5219",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0a/0f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz",
+        "sha512": "c42c1fb82663848ab2efe1cac412eb0d54f9abf8aaed70550572e7e7b453208a5e94bb442191d7005fd4a5adfe81a0a9795d4d352e59f40f880fa8e7e74543e0",
+        "dest-filename": "1fb82663848ab2efe1cac412eb0d54f9abf8aaed70550572e7e7b453208a5e94bb442191d7005fd4a5adfe81a0a9795d4d352e59f40f880fa8e7e74543e0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/2c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz",
+        "sha512": "bf17771bfc9b2934a59b7d4c380f7a82abeb446bfd449ecb1ad6429f656b73986d034cc20ef70ca949227dc8eb58d34a5c7514dd60a460ecf3552141774c1adb",
+        "dest-filename": "771bfc9b2934a59b7d4c380f7a82abeb446bfd449ecb1ad6429f656b73986d034cc20ef70ca949227dc8eb58d34a5c7514dd60a460ecf3552141774c1adb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/17"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz",
+        "sha512": "ece7221d3da52827b0474985a01aef649e005d331efec60e7bcef6f3d5805623a87049838e3bfc32f20e4f65c44ae2a3f63a7cbb74996144a1f3d400e12d6443",
+        "dest-filename": "221d3da52827b0474985a01aef649e005d331efec60e7bcef6f3d5805623a87049838e3bfc32f20e4f65c44ae2a3f63a7cbb74996144a1f3d400e12d6443",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/e7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz",
+        "sha512": "897d668261ab5dd00d8612136e9a764103367c67a106c7bd2db4dfd2c89d58aeb283f344fae855e5d7d4d60e8460f95c45e626904f502cfabfda2aca026b52f7",
+        "dest-filename": "668261ab5dd00d8612136e9a764103367c67a106c7bd2db4dfd2c89d58aeb283f344fae855e5d7d4d60e8460f95c45e626904f502cfabfda2aca026b52f7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/7d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz",
+        "sha512": "5bb495006051fc85fbce6d6def462e8e96e4fb374fabfbb8b287854a49d615d5c816e5ac04604e52efd39ff23a28748abd287dd4e88cb9a4a7629de6b4fb7921",
+        "dest-filename": "95006051fc85fbce6d6def462e8e96e4fb374fabfbb8b287854a49d615d5c816e5ac04604e52efd39ff23a28748abd287dd4e88cb9a4a7629de6b4fb7921",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5b/b4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz",
+        "sha512": "f3b2a0517113d3d0918c60a2d848f1cb73d42d79daeb7fdb318bfbdad080943242dd8ab0967d0788527754932cb76fa612d36d66ee6816f5f8a891a32ac9c082",
+        "dest-filename": "a0517113d3d0918c60a2d848f1cb73d42d79daeb7fdb318bfbdad080943242dd8ab0967d0788527754932cb76fa612d36d66ee6816f5f8a891a32ac9c082",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz",
+        "sha512": "5f39a76f9f3e0dbefc813fc20a3fcf542bcafb3c5b9ecc3a17e3b5a21798b3325b0527448d58508b70bf5edb73c608bf18b9a9bce82046cd51169889f3e737e1",
+        "dest-filename": "a76f9f3e0dbefc813fc20a3fcf542bcafb3c5b9ecc3a17e3b5a21798b3325b0527448d58508b70bf5edb73c608bf18b9a9bce82046cd51169889f3e737e1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/39"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.3.tgz",
+        "sha512": "4e518f90b14b54e6374fb7d9af076f2a98e9ad1dece1fc51967d0e443a35550ec71f2c49c1396b8ca5379295564e56808c812e093a249a39199ebf13a5cf76e7",
+        "dest-filename": "8f90b14b54e6374fb7d9af076f2a98e9ad1dece1fc51967d0e443a35550ec71f2c49c1396b8ca5379295564e56808c812e093a249a39199ebf13a5cf76e7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/51"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.5.4.tgz",
+        "sha512": "bacb95be5eb376a224520425a1dc6fbc5051ec7219223590a907a69dcef2b2a10fe23b9b2ec0da68e862240c15cfc3e5ae404946e1e40ba3c2bb1f8e70417a86",
+        "dest-filename": "95be5eb376a224520425a1dc6fbc5051ec7219223590a907a69dcef2b2a10fe23b9b2ec0da68e862240c15cfc3e5ae404946e1e40ba3c2bb1f8e70417a86",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ba/cb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.26.tgz",
+        "sha512": "847d12322b4cc67078dce669c85d4814f4bd6e06f62376e90a1efa9b65842bb044d00d04ce962c469d02087db134ab21afb91a714e534012d89f8ce3ec21bad0",
+        "dest-filename": "12322b4cc67078dce669c85d4814f4bd6e06f62376e90a1efa9b65842bb044d00d04ce962c469d02087db134ab21afb91a714e534012d89f8ce3ec21bad0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/84/7d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.26.tgz",
+        "sha512": "249c344edfe4485b08466813405e094adf35014488d5a1327b9665eb911e67c1f7e491e74ef1469a90ce067e623b1778f1fc8613e66f641a7915c800cbfd5087",
+        "dest-filename": "344edfe4485b08466813405e094adf35014488d5a1327b9665eb911e67c1f7e491e74ef1469a90ce067e623b1778f1fc8613e66f641a7915c800cbfd5087",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/9c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.26.tgz",
+        "sha512": "37cede70b0f8f12a7acd5f73203ff9cae4b5fb97e88f40dfb9819d43a2878ff21b2afc8abf5ccd5fa5429a7298c2d98769d10eea615cd842884a2bb74433c0bc",
+        "dest-filename": "de70b0f8f12a7acd5f73203ff9cae4b5fb97e88f40dfb9819d43a2878ff21b2afc8abf5ccd5fa5429a7298c2d98769d10eea615cd842884a2bb74433c0bc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/ce"
     },
     {
         "type": "file",
@@ -475,13 +762,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.5.tgz",
-        "sha512": "c89aa7580009152f84cc533f4d18289eb78088efc874b54bbe53b13b36349841848207e7ba2cf3812450c11d3426d800f490b88109302929cdc245afe281c7d9",
-        "dest-filename": "a7580009152f84cc533f4d18289eb78088efc874b54bbe53b13b36349841848207e7ba2cf3812450c11d3426d800f490b88109302929cdc245afe281c7d9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/9a"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.25.tgz",
         "sha512": "e167b438070c66c2a06281a5323cd8bdaa04ae5b5d148dbfdb9c2a6a7b93bbe4b8822b2639345304f8b820048e8f159dcc8c2b6128e7a8e35f2afbaa917cc4d9",
         "dest-filename": "b438070c66c2a06281a5323cd8bdaa04ae5b5d148dbfdb9c2a6a7b93bbe4b8822b2639345304f8b820048e8f159dcc8c2b6128e7a8e35f2afbaa917cc4d9",
@@ -489,73 +769,59 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.5.tgz",
-        "sha512": "0f4032e7c108ecc3e34e2b7ea027e3005a08f68f7fc1cfa75bd1a780ba433e26dfa2fe48416c59fd04a68f1fe8d4c0196fb1afe704cb18e6e854bf0e05f01db0",
-        "dest-filename": "32e7c108ecc3e34e2b7ea027e3005a08f68f7fc1cfa75bd1a780ba433e26dfa2fe48416c59fd04a68f1fe8d4c0196fb1afe704cb18e6e854bf0e05f01db0",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/40"
+        "url": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
+        "sha512": "3d480aa76ae7f1f16c23efa5176b0eee0c0ed9df588f9ed4b6be7212c0dfdc635a41ca3008b28beec7fe2ef545bed2435d4a7fd37f9d0ba7f6f8b0afe5a2b56a",
+        "dest-filename": "0aa76ae7f1f16c23efa5176b0eee0c0ed9df588f9ed4b6be7212c0dfdc635a41ca3008b28beec7fe2ef545bed2435d4a7fd37f9d0ba7f6f8b0afe5a2b56a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3d/48"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.5.tgz",
-        "sha512": "1b856c5d3a9d1f2f96d63764b14dd2eadc30b7794cfc335b37608cb88709b7b235cf08fdee7fa246982fefb93740289e0d0ef1357adf1b778cb7f5d8e1ea5548",
-        "dest-filename": "6c5d3a9d1f2f96d63764b14dd2eadc30b7794cfc335b37608cb88709b7b235cf08fdee7fa246982fefb93740289e0d0ef1357adf1b778cb7f5d8e1ea5548",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1b/85"
+        "url": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz",
+        "sha512": "ae2b4f48a2c170f6ab9ec2988be18db5b75bac81359adb85109e14d6c59eb8e32523388ae46b4e2fce6de5186c372e2e5885cf824f8e51da675e24ddce7f28dc",
+        "dest-filename": "4f48a2c170f6ab9ec2988be18db5b75bac81359adb85109e14d6c59eb8e32523388ae46b4e2fce6de5186c372e2e5885cf824f8e51da675e24ddce7f28dc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ae/2b"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.5.tgz",
-        "sha512": "53764bd64b2ba7f1a8fbc5c6e0cd9e5a8aa17a32bdbfbe161d667b16e5e28b561495c4536c576dacd0ee6305bd6c2ca6376f551fdd7fad3df6a398b6eba84fae",
-        "dest-filename": "4bd64b2ba7f1a8fbc5c6e0cd9e5a8aa17a32bdbfbe161d667b16e5e28b561495c4536c576dacd0ee6305bd6c2ca6376f551fdd7fad3df6a398b6eba84fae",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/53/76"
+        "url": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+        "sha512": "b068533ccb97a99d6b54e937d91ca5ced5a47d74d186e4bbbe000abf4ce3aa4f206ec1e427bc5f15ffa36f24b1b7bb5639b109c3229a1cc8a457f5860e2426f2",
+        "dest-filename": "533ccb97a99d6b54e937d91ca5ced5a47d74d186e4bbbe000abf4ce3aa4f206ec1e427bc5f15ffa36f24b1b7bb5639b109c3229a1cc8a457f5860e2426f2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/68"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.5.tgz",
-        "sha512": "fb67016a80531e12e33ac81138f7e7bb0f8343f1d3141febdc4f350ccb19175676162c8b4aba306cc4f124c758f1b1c0fc7d226ea30251e3cd979108ec0f6d74",
-        "dest-filename": "016a80531e12e33ac81138f7e7bb0f8343f1d3141febdc4f350ccb19175676162c8b4aba306cc4f124c758f1b1c0fc7d226ea30251e3cd979108ec0f6d74",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/67"
+        "url": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.8.tgz",
+        "sha512": "3dfc005bb04ba29a9a25b9de0a134be9c50e4cbdc62fed25f296983f9b21860639b6804d89d5a731758cfaa0f02fb302f7ecc3b73085d9e9d3f2be953eeeb88b",
+        "dest-filename": "005bb04ba29a9a25b9de0a134be9c50e4cbdc62fed25f296983f9b21860639b6804d89d5a731758cfaa0f02fb302f7ecc3b73085d9e9d3f2be953eeeb88b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3d/fc"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.5.tgz",
-        "sha512": "14c72acb358dfac6017aa44c58f193d906349946ac64c548b87be66f9353dde7aa3eb6c7058b423fc2561140830a033e66beb6bae598feaa1e06b3ebcdf6bbf3",
-        "dest-filename": "2acb358dfac6017aa44c58f193d906349946ac64c548b87be66f9353dde7aa3eb6c7058b423fc2561140830a033e66beb6bae598feaa1e06b3ebcdf6bbf3",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/c7"
+        "url": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz",
+        "sha512": "e717c0ca90907a9bf8268835538ce7f1c64871b28a1646b702058710541e2bae4e5be62ce17c9b3facf690a830b38601e37286a6aa790ff2b7828d943cfba72c",
+        "dest-filename": "c0ca90907a9bf8268835538ce7f1c64871b28a1646b702058710541e2bae4e5be62ce17c9b3facf690a830b38601e37286a6aa790ff2b7828d943cfba72c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/17"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.5.tgz",
-        "sha512": "a3042bdbdb5d2a46b374f6f969a1d61676ed62cbdcc9f940b2caa075eee43fa32536986c0ed75839d0df7cdd777f2e7846f1158795d8031b11b07122715bd5f7",
-        "dest-filename": "2bdbdb5d2a46b374f6f969a1d61676ed62cbdcc9f940b2caa075eee43fa32536986c0ed75839d0df7cdd777f2e7846f1158795d8031b11b07122715bd5f7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/04"
+        "url": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz",
+        "sha512": "67be75bf6d37616c18cf2e3ad1bcec6102120df3e31d397ee99cf0a3f6b70ac01ffb471c12343c73ed02757d56b2e9914c77b2c2fc9416d5ba2af36e913fec98",
+        "dest-filename": "75bf6d37616c18cf2e3ad1bcec6102120df3e31d397ee99cf0a3f6b70ac01ffb471c12343c73ed02757d56b2e9914c77b2c2fc9416d5ba2af36e913fec98",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/be"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.5.tgz",
-        "sha512": "3aca84b3e647bbe2cde2654b1ce2718952fcefa6d8b669b8b7d22ba89898822c605a4e0a777049232b93ccdd2614a7d230751e21288797381c30f784c9054692",
-        "dest-filename": "84b3e647bbe2cde2654b1ce2718952fcefa6d8b669b8b7d22ba89898822c605a4e0a777049232b93ccdd2614a7d230751e21288797381c30f784c9054692",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/ca"
+        "url": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz",
+        "sha512": "6b85ab91815b6f5f62f698e4cf7f3324183cc1afeb6e834446adfe85145bd1d1e2261d7773eea401b82a08f7cc689da0838c1e583dc03d9b3001239f98ac1a98",
+        "dest-filename": "ab91815b6f5f62f698e4cf7f3324183cc1afeb6e834446adfe85145bd1d1e2261d7773eea401b82a08f7cc689da0838c1e583dc03d9b3001239f98ac1a98",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/85"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.5.tgz",
-        "sha512": "06c79173e254f402f86febebee09c98825ded2bbe54ab814323247d86930b3d114ba3c970d04fa410599aeb2f9544e9fa6067ec3254e83f324f1a8af06fdc26e",
-        "dest-filename": "9173e254f402f86febebee09c98825ded2bbe54ab814323247d86930b3d114ba3c970d04fa410599aeb2f9544e9fa6067ec3254e83f324f1a8af06fdc26e",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/c7"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.5.tgz",
-        "sha512": "68ee026038450f23702e77cc8badfacdb453c8680fa9ab3dc2c0727619cc6000571ee337399a44e6b14f0dd2393c27367e7e20a5a8c3fc54ca1ef90cbdbd1fd7",
-        "dest-filename": "026038450f23702e77cc8badfacdb453c8680fa9ab3dc2c0727619cc6000571ee337399a44e6b14f0dd2393c27367e7e20a5a8c3fc54ca1ef90cbdbd1fd7",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/ee"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.5.tgz",
-        "sha512": "71f7250721f7297ceac41226217f1d9532c8ddba338fdf77456085bf73139d330f91e59aec787da8f5f07c57f2c3d4cee4e1d83bdad69c5c3e0cbc5c055154cd",
-        "dest-filename": "250721f7297ceac41226217f1d9532c8ddba338fdf77456085bf73139d330f91e59aec787da8f5f07c57f2c3d4cee4e1d83bdad69c5c3e0cbc5c055154cd",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/f7"
+        "url": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz",
+        "sha512": "509697479e2f306eb58bc5cd2334d27f643b30ea991e9a7cfb1dd72c6b44dfe7cbfa741dfa4ecee7e5f70ffb96ae741739d330e553e287e52b7a6730faed70a1",
+        "dest-filename": "97479e2f306eb58bc5cd2334d27f643b30ea991e9a7cfb1dd72c6b44dfe7cbfa741dfa4ecee7e5f70ffb96ae741739d330e553e287e52b7a6730faed70a1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/96"
     },
     {
         "type": "file",
@@ -566,17 +832,31 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.5.tgz",
-        "sha512": "937d526ac477f3c769e9ead0dc6f55e1f1ccf1ec2f25270733ec2ab8d89534011a65dbe3b1f55d69efba32071f966bf65283eedff3d62536a287fc0a3bf8c613",
-        "dest-filename": "526ac477f3c769e9ead0dc6f55e1f1ccf1ec2f25270733ec2ab8d89534011a65dbe3b1f55d69efba32071f966bf65283eedff3d62536a287fc0a3bf8c613",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/7d"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz",
         "sha512": "68aedf78858f5c549486c08ff4f16a3f214e733e043646fc859da99de2fa9b65230a471cbda3a10bfe4a08a96eb81b9fbe9d8ace46dd0365b6a64db4bcbceede",
         "dest-filename": "df78858f5c549486c08ff4f16a3f214e733e043646fc859da99de2fa9b65230a471cbda3a10bfe4a08a96eb81b9fbe9d8ace46dd0365b6a64db4bcbceede",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/ae"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+        "sha512": "aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
+        "dest-filename": "6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ae/af"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+        "sha512": "359c896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e",
+        "dest-filename": "896ab05f2fb9d6c08abe1432fa669ff21c485e3cc3679c9d32dea7e2782ae636f61cb7cbafb62578d54be549ee9aa407e4d1f63515b5b1f8dc1f9a9bed4e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/9c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+        "sha512": "8f77d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2",
+        "dest-filename": "d52e0bd3a39dbb6a7c98c893864d825b1bebe79d062f1349b99a691cd532be9f1029a6408b3082f4699e1d6e55423681928619be933138654ca4068320e2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/77"
     },
     {
         "type": "file",
@@ -587,10 +867,241 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+        "sha512": "cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+        "dest-filename": "7dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/b0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+        "sha512": "1ea679ad69458c6895d2d0e6dd4c7180d46ab0e4e78aaa0a66ed292007e1ed3650306b992be847d1daf24adcb4b22d105e3d627a8a78f929127cf6413cf9078a",
+        "dest-filename": "79ad69458c6895d2d0e6dd4c7180d46ab0e4e78aaa0a66ed292007e1ed3650306b992be847d1daf24adcb4b22d105e3d627a8a78f929127cf6413cf9078a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/a6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+        "sha512": "8b1892d272cd346e63350ce064936852904a768f724d864c189f90813da39a347b1bbf901d109ce2fe8b43736013b10126afa8d1a9acdf0689c24ae50689bc22",
+        "dest-filename": "92d272cd346e63350ce064936852904a768f724d864c189f90813da39a347b1bbf901d109ce2fe8b43736013b10126afa8d1a9acdf0689c24ae50689bc22",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/18"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+        "sha512": "f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+        "dest-filename": "56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/ef"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+        "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+        "dest-filename": "9e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/84"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+        "sha512": "4a0d31254343535b0934675f1968551d7d24919f8759cbe65729896e3e8d4a0659996ffc4bd6361d0e5ebb2b672206a483137aa5aa4e0168b00e8d5cb450dca1",
+        "dest-filename": "31254343535b0934675f1968551d7d24919f8759cbe65729896e3e8d4a0659996ffc4bd6361d0e5ebb2b672206a483137aa5aa4e0168b00e8d5cb450dca1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/0d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+        "sha512": "25939203b328f6c34607cf948d283374bb68916024cb5cdbced3375912c26d9ef4ff771300d99098e751ef2da0f89d1ed965f2c32d724b8ebcb58f88aeea84c3",
+        "dest-filename": "9203b328f6c34607cf948d283374bb68916024cb5cdbced3375912c26d9ef4ff771300d99098e751ef2da0f89d1ed965f2c32d724b8ebcb58f88aeea84c3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/93"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+        "sha512": "f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772",
+        "dest-filename": "548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/3f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+        "sha512": "26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d",
+        "dest-filename": "2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/dd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+        "sha512": "642e417742e02578301aa5249d963fbe4510d38afc3579c9677c988b8bc3992899982fe975237435b3513f16696ed3b8b807c350015f7cef086683371a3f0890",
+        "dest-filename": "417742e02578301aa5249d963fbe4510d38afc3579c9677c988b8bc3992899982fe975237435b3513f16696ed3b8b807c350015f7cef086683371a3f0890",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/2e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
+        "sha512": "6e45d8f56b15a58ec2bcc84a491ea9662959bbd2e7e560eb2950545dfd92e38ddeb649843b8579f2179379c5dc508b0db22e11c7c2543b835f5f521c425e1d7a",
+        "dest-filename": "d8f56b15a58ec2bcc84a491ea9662959bbd2e7e560eb2950545dfd92e38ddeb649843b8579f2179379c5dc508b0db22e11c7c2543b835f5f521c425e1d7a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/45"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+        "sha512": "6fa225bacf9cdd1add0e4f8984b2940107f3ce02c43f2eb0717a92edfff17b51044efb033fa18e446ed216e3ace9c203e5892a7215bf2d765b5f96dcf23ed971",
+        "dest-filename": "25bacf9cdd1add0e4f8984b2940107f3ce02c43f2eb0717a92edfff17b51044efb033fa18e446ed216e3ace9c203e5892a7215bf2d765b5f96dcf23ed971",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/a2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+        "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
+        "dest-filename": "6302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3f/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
+        "sha512": "245f69b6ed6f3f6728cfdf3ee74e758d9e0fc1081dda78bc03e81848dec403b74f28831fd290e5494c6176654e695dff7d82b9b960648125c96912ebe3edc0ea",
+        "dest-filename": "69b6ed6f3f6728cfdf3ee74e758d9e0fc1081dda78bc03e81848dec403b74f28831fd290e5494c6176654e695dff7d82b9b960648125c96912ebe3edc0ea",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/5f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+        "sha512": "7b2ac5d23885a58fb776b4fadfcddfd6a8646c6b0b4a27cd02303ad4852366398b0968c8b58e8b07d7edf588680e0c1f99c941db386ee752dcefef796fc35102",
+        "dest-filename": "c5d23885a58fb776b4fadfcddfd6a8646c6b0b4a27cd02303ad4852366398b0968c8b58e8b07d7edf588680e0c1f99c941db386ee752dcefef796fc35102",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/2a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+        "sha512": "a0a9db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+        "dest-filename": "db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/a9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+        "sha512": "1d14324e4dbf60f124b7d4e750f6cea6beb8530dca3a270558f5416fec621ef77a781c7fa8fafdc6a7c11434fc3f6bd6b2fbf3e236c491f0deef55b757236edb",
+        "dest-filename": "324e4dbf60f124b7d4e750f6cea6beb8530dca3a270558f5416fec621ef77a781c7fa8fafdc6a7c11434fc3f6bd6b2fbf3e236c491f0deef55b757236edb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1d/14"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+        "sha512": "b21c7ba10d00c1e9ff05121d92392fcf9e0f9c4108fc48f05c3488669f3afca29d6da7c78750dffd16060619f885b7b6fae282f459d3e540847723f3dda8bd85",
+        "dest-filename": "7ba10d00c1e9ff05121d92392fcf9e0f9c4108fc48f05c3488669f3afca29d6da7c78750dffd16060619f885b7b6fae282f459d3e540847723f3dda8bd85",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b2/1c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+        "sha512": "59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
+        "dest-filename": "b6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/dc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+        "sha512": "19f8ac119109bf32ab9865a4bdf860cdccff06594dd5449ea83d95ead835e0e00e81a083d99fcf504bb19c067f9cfbe6687446edaf32efba754ff2114380f51f",
+        "dest-filename": "ac119109bf32ab9865a4bdf860cdccff06594dd5449ea83d95ead835e0e00e81a083d99fcf504bb19c067f9cfbe6687446edaf32efba754ff2114380f51f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/f8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+        "sha512": "4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+        "dest-filename": "023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/11"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+        "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+        "dest-filename": "bedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/ec"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+        "sha512": "6ee869e6478fae675adef85ce41f6dee95105c06f64e7774aa0a642213e19075f126988f275d47d19114d28069276433b526f31bf671323fc21ec609a911e6ca",
+        "dest-filename": "69e6478fae675adef85ce41f6dee95105c06f64e7774aa0a642213e19075f126988f275d47d19114d28069276433b526f31bf671323fc21ec609a911e6ca",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/e8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+        "sha512": "fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+        "dest-filename": "efe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/2a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+        "sha512": "44cb66c3488591e478615f9f50e4ae72b88040d6fd83ccc5479d8c582b65f9c09938544d2facde077f79bcfcc58448e39f87ccc57b9d9842e797f285fd6acaeb",
+        "dest-filename": "66c3488591e478615f9f50e4ae72b88040d6fd83ccc5479d8c582b65f9c09938544d2facde077f79bcfcc58448e39f87ccc57b9d9842e797f285fd6acaeb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/cb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+        "sha512": "d4d07e04aaa1b4d8a932ca2fe3123f3678422a9f571bd35a998a793d59bd925013d1fb2b34f8da1480ac08584d87064928d87bcc1ff7abca97cf413da1a30db5",
+        "dest-filename": "7e04aaa1b4d8a932ca2fe3123f3678422a9f571bd35a998a793d59bd925013d1fb2b34f8da1480ac08584d87064928d87bcc1ff7abca97cf413da1a30db5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/d0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
+        "sha512": "2067eece767f9fb2a9f7e9f2a5a98186fc1dc0bb16e8a0bc20e694470d9da002b97bdf001b769c54b761d30a0e9c4a827d4b52f95bbcf36244e24fc3026dc8b5",
+        "dest-filename": "eece767f9fb2a9f7e9f2a5a98186fc1dc0bb16e8a0bc20e694470d9da002b97bdf001b769c54b761d30a0e9c4a827d4b52f95bbcf36244e24fc3026dc8b5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/67"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+        "sha512": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+        "dest-filename": "903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/5d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+        "sha512": "fd36ff25c8cad75d67352706a1be4c36db27b4d3356823540e2a41fd39306458720ebac4e3b48ec7fd7cc05d9b6e381cdd9cc248a5b54f99ede446c5a00cff56",
+        "dest-filename": "ff25c8cad75d67352706a1be4c36db27b4d3356823540e2a41fd39306458720ebac4e3b48ec7fd7cc05d9b6e381cdd9cc248a5b54f99ede446c5a00cff56",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/36"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
         "sha512": "cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
         "dest-filename": "c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/51"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+        "sha512": "446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+        "dest-filename": "305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/6c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+        "sha512": "73a7dc125355e9286d6579ac80d805155e6d557d8f695e20f8c38091bf1e5c7be7eacaf2241ad96bdaf4cd5ebe76d4f2a022b1b43cb9b7243967042e89db5df9",
+        "dest-filename": "dc125355e9286d6579ac80d805155e6d557d8f695e20f8c38091bf1e5c7be7eacaf2241ad96bdaf4cd5ebe76d4f2a022b1b43cb9b7243967042e89db5df9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/a7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+        "sha512": "a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d",
+        "dest-filename": "f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/83"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+        "sha512": "d237bea8f28710ca21bdf453084a370ab3c6e9c033018826ccacb1462612483912e9e1897725499bb59a600e4409a003f702c1d93e0411eca603968555c61708",
+        "dest-filename": "bea8f28710ca21bdf453084a370ab3c6e9c033018826ccacb1462612483912e9e1897725499bb59a600e4409a003f702c1d93e0411eca603968555c61708",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/37"
     },
     {
         "type": "file",
@@ -601,6 +1112,41 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+        "sha512": "456988aa17057f5951601bcd9abeea4cdbb20adffbfe7b368dba69d7e3da96013fac341c053d1f8a848c52927dde2ae55210b986b838718a9ee94fb42265b4ac",
+        "dest-filename": "88aa17057f5951601bcd9abeea4cdbb20adffbfe7b368dba69d7e3da96013fac341c053d1f8a848c52927dde2ae55210b986b838718a9ee94fb42265b4ac",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/69"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+        "sha512": "93580201702c3602f010bf98f16be5f8cea81058f96e06b37d950ba52e429dea0f3d745a0825bb766faadb52b2d95104e57f957910c1560d4f72fbecaf84ed35",
+        "dest-filename": "0201702c3602f010bf98f16be5f8cea81058f96e06b37d950ba52e429dea0f3d745a0825bb766faadb52b2d95104e57f957910c1560d4f72fbecaf84ed35",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/58"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
+        "sha512": "d03aeeb26e8c5515d2389a466da49581c42cb81e211243291d7695b2d70f9a1bb92c879dc6cd7134afe7231990214fd13c2d3ed7fa3401565f05391334939d53",
+        "dest-filename": "eeb26e8c5515d2389a466da49581c42cb81e211243291d7695b2d70f9a1bb92c879dc6cd7134afe7231990214fd13c2d3ed7fa3401565f05391334939d53",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/3a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+        "sha512": "8ba5330ec70efd77c070d603ef909f2029267cb79da723c3768ceb2cc99073939169071d328736d4e9e513294c22a23b53c7a788aacf331c6d8fc934be198984",
+        "dest-filename": "330ec70efd77c070d603ef909f2029267cb79da723c3768ceb2cc99073939169071d328736d4e9e513294c22a23b53c7a788aacf331c6d8fc934be198984",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/a5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
+        "sha512": "2e040c338597537408f9262011cda58918339da0f9a236e6637b1bf0bc7282e564220e45c5da5392f93bdad7b6477f3f4c62b11fadf8a0bc5744663a77b00ff9",
+        "dest-filename": "0c338597537408f9262011cda58918339da0f9a236e6637b1bf0bc7282e564220e45c5da5392f93bdad7b6477f3f4c62b11fadf8a0bc5744663a77b00ff9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2e/04"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
         "sha512": "5748631f87463e1f40a39a74328458e8156ab700a3873eaf2392d3f00279e47fb883dff8bdb1f1d48e787d2d17b9c94b8431c0acf40288c8c3c6368bf1f3f187",
         "dest-filename": "631f87463e1f40a39a74328458e8156ab700a3873eaf2392d3f00279e47fb883dff8bdb1f1d48e787d2d17b9c94b8431c0acf40288c8c3c6368bf1f3f187",
@@ -608,10 +1154,262 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-        "sha512": "8ddd1fe0d1db0fa7002c2c861253691803ad5b14aae3a97d5ffb160743737797abe0acf66139be565d2a2854fd29426f0fcf9f88ef00be81e116f11ab5f562c4",
-        "dest-filename": "1fe0d1db0fa7002c2c861253691803ad5b14aae3a97d5ffb160743737797abe0acf66139be565d2a2854fd29426f0fcf9f88ef00be81e116f11ab5f562c4",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8d/dd"
+        "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
+        "sha512": "c98df9299724249b9554f5e9be3831882b951094faec5eb30de553bf8ae2cf23eb7c6054a5942cbe6c6737e0b7ef57367ac0ff84d3238f8b69061bae78b37b68",
+        "dest-filename": "f9299724249b9554f5e9be3831882b951094faec5eb30de553bf8ae2cf23eb7c6054a5942cbe6c6737e0b7ef57367ac0ff84d3238f8b69061bae78b37b68",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/8d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+        "sha512": "5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+        "dest-filename": "f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/48"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "sha512": "bdb468ac1e455105af95ad7a53c47faa06852326b6a86cf00eb366099b982ab6dd494306e88d5908641179f911561b8e9081959deec1437e4349fa35aaf26a16",
+        "dest-filename": "68ac1e455105af95ad7a53c47faa06852326b6a86cf00eb366099b982ab6dd494306e88d5908641179f911561b8e9081959deec1437e4349fa35aaf26a16",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/b4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+        "sha512": "4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+        "dest-filename": "5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/da"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+        "sha512": "fef798ef925b30ae23d728efb94c6e56c892fe1affe221ecf454d3e9c8137b1c5d1342f2fe095c7010249681ff0e87e48d16d95376e7a23dfc98e9a1919d251f",
+        "dest-filename": "98ef925b30ae23d728efb94c6e56c892fe1affe221ecf454d3e9c8137b1c5d1342f2fe095c7010249681ff0e87e48d16d95376e7a23dfc98e9a1919d251f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/f7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+        "sha512": "df3def15ec4a2049e31c4df308c468e9f9ff7b8e14ed3d648548e0f87a746503028a0876f2b00b0f49cf14170666e88b0b9acb65adae6d01c34659f4f497d4d9",
+        "dest-filename": "ef15ec4a2049e31c4df308c468e9f9ff7b8e14ed3d648548e0f87a746503028a0876f2b00b0f49cf14170666e88b0b9acb65adae6d01c34659f4f497d4d9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/3d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz",
+        "sha512": "bc0507633b9ee1801ada13400a307c1ef5108f9c9e8406608829721555689bd70ff33e4d485ab73f007f4ed26c94ddb300c8115fa1421428d805b421ef583945",
+        "dest-filename": "07633b9ee1801ada13400a307c1ef5108f9c9e8406608829721555689bd70ff33e4d485ab73f007f4ed26c94ddb300c8115fa1421428d805b421ef583945",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/05"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-config-flat-gitignore/-/eslint-config-flat-gitignore-2.1.0.tgz",
+        "sha512": "709ccd27b2fea6c5a9e665ccee3057f9f8c7b41bef874e9106573078c84a0fc8d6a90c341bbf21396e6da5500b1871853ec055fa8b761fea5d0c6272e8257ca4",
+        "dest-filename": "cd27b2fea6c5a9e665ccee3057f9f8c7b41bef874e9106573078c84a0fc8d6a90c341bbf21396e6da5500b1871853ec055fa8b761fea5d0c6272e8257ca4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/9c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-flat-config-utils/-/eslint-flat-config-utils-2.1.4.tgz",
+        "sha512": "6c49e653982acd2fb83be89df6fadb3f8def0728c5fbc28eb3e42eb95e0e96a02e5e69d15b6cdf23f4736b57d0bdd8a14398780d4a3436a140895883e264abcd",
+        "dest-filename": "e653982acd2fb83be89df6fadb3f8def0728c5fbc28eb3e42eb95e0e96a02e5e69d15b6cdf23f4736b57d0bdd8a14398780d4a3436a140895883e264abcd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/49"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.1.tgz",
+        "sha512": "63312875b0f25bc0d7f1b2262a101c09ebbf2f7d4377fef4062771d907b1f4e154b60cd72eab5f58be07af97ccfda08207c41464bb89babd12f64e947e01647e",
+        "dest-filename": "2875b0f25bc0d7f1b2262a101c09ebbf2f7d4377fef4062771d907b1f4e154b60cd72eab5f58be07af97ccfda08207c41464bb89babd12f64e947e01647e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/31"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-merge-processors/-/eslint-merge-processors-2.0.0.tgz",
+        "sha512": "b14ba149fdc8ac9746a28aae1140794cda4636906841c71b9da2c7b1bd579012d43cfa82362bc2a58d3965ca423a257db87c0edb2c5711655ccd5725cccc5894",
+        "dest-filename": "a149fdc8ac9746a28aae1140794cda4636906841c71b9da2c7b1bd579012d43cfa82362bc2a58d3965ca423a257db87c0edb2c5711655ccd5725cccc5894",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/4b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-antfu/-/eslint-plugin-antfu-3.1.1.tgz",
+        "sha512": "ed0f8d8702df1c916fa292361c165b4b15979e04f004b2b15b50065cbaf69441b170420afc0b03b3ca67f1fbc88b39796998c16d56d52b9ba398ca417b84ef76",
+        "dest-filename": "8d8702df1c916fa292361c165b4b15979e04f004b2b15b50065cbaf69441b170420afc0b03b3ca67f1fbc88b39796998c16d56d52b9ba398ca417b84ef76",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/0f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-command/-/eslint-plugin-command-3.4.0.tgz",
+        "sha512": "116e1e83f6bb4ca1211b4b39204b62ef6921dd839396785f14db9cb6ae569c1d5fb2ddfbfc81d37793a40febe79517f7a294ef51c4918a101ab5e3fa6d3e5970",
+        "dest-filename": "1e83f6bb4ca1211b4b39204b62ef6921dd839396785f14db9cb6ae569c1d5fb2ddfbfc81d37793a40febe79517f7a294ef51c4918a101ab5e3fa6d3e5970",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/11/6e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+        "sha512": "ec3b3cfb0000a15dd3f8b00a7aedfd6390735c2ac62ab70849f80a12a4d2e010cdf121440d07744b8de3890f2f21adf050a0f4eea8ad65d7f395e9d28bcff4a9",
+        "dest-filename": "3cfb0000a15dd3f8b00a7aedfd6390735c2ac62ab70849f80a12a4d2e010cdf121440d07744b8de3890f2f21adf050a0f4eea8ad65d7f395e9d28bcff4a9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/3b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-import-lite/-/eslint-plugin-import-lite-0.3.1.tgz",
+        "sha512": "f7e101c8765ab6f5859ff951b148dae69c1a874539961380e925ea4c8fe2233a082473209ac1d41c469394bcca53fba4c8247028453913dd9a51444f8155aad0",
+        "dest-filename": "01c8765ab6f5859ff951b148dae69c1a874539961380e925ea4c8fe2233a082473209ac1d41c469394bcca53fba4c8247028453913dd9a51444f8155aad0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/e1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.5.0.tgz",
+        "sha512": "3d1f3578e1aae12edd8959d5f71cc548113808310d45018fd0b72491e93c01d1ed6e3fba066d1c22dc25167c6c2c5ae2247b29884de6a6ef14db478e0f24e822",
+        "dest-filename": "3578e1aae12edd8959d5f71cc548113808310d45018fd0b72491e93c01d1ed6e3fba066d1c22dc25167c6c2c5ae2247b29884de6a6ef14db478e0f24e822",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3d/1f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.21.0.tgz",
+        "sha512": "1edb65c5d346e65cb76233f570530feb6478a8a2f125445f059a36827318fb24288d9c642f23a96351f52914ca066bd07921bda48a521848438c4d7bbef628b2",
+        "dest-filename": "65c5d346e65cb76233f570530feb6478a8a2f125445f059a36827318fb24288d9c642f23a96351f52914ca066bd07921bda48a521848438c4d7bbef628b2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/db"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.23.1.tgz",
+        "sha512": "ebc3de6a55296281ce061df7d892cb0fd4a3ece4140e416999c7eab7c47db3249f1527ae1898cc4c942f091441f7accedc0fcf10b44b90faf3b079b3105410e4",
+        "dest-filename": "de6a55296281ce061df7d892cb0fd4a3ece4140e416999c7eab7c47db3249f1527ae1898cc4c942f091441f7accedc0fcf10b44b90faf3b079b3105410e4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/c3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+        "sha512": "6eb70a7311a721237609c5615c9fe411094d6b43047c646dc0ab56035e9292a5c72a2b5a28832b7de98928b297d58a835390bfe496373ef6577798c45b4e1ed1",
+        "dest-filename": "0a7311a721237609c5615c9fe411094d6b43047c646dc0ab56035e9292a5c72a2b5a28832b7de98928b297d58a835390bfe496373ef6577798c45b4e1ed1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/b7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.15.1.tgz",
+        "sha512": "307174701a0e1b45f205fec6d040050ae249bb8235f30cb4cc0a13d4e1dfc76a3a10ec751054c8cebd8719eb996b590372eb285f4c49f55ee866669e15defbdd",
+        "dest-filename": "74701a0e1b45f205fec6d040050ae249bb8235f30cb4cc0a13d4e1dfc76a3a10ec751054c8cebd8719eb996b590372eb285f4c49f55ee866669e15defbdd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/71"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-pnpm/-/eslint-plugin-pnpm-1.4.3.tgz",
+        "sha512": "c1d5ab9163799b14601000e442fc70bf4c40fb4fbefe16030f93b25d32fa52a3cb50f75c0854093bad4d3bb20a844a9bdc67255acd363a816cd4c11337e6b7cd",
+        "dest-filename": "ab9163799b14601000e442fc70bf4c40fb4fbefe16030f93b25d32fa52a3cb50f75c0854093bad4d3bb20a844a9bdc67255acd363a816cd4c11337e6b7cd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/d5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-2.10.0.tgz",
+        "sha512": "a2fcd04fc112567e6839ee5aee02033c3e6ff5b0928c8149bb9eec54f0ea80f45789c4333a761f14ddb55a8401405d7cbeb853e68ed430a1702505558f22749e",
+        "dest-filename": "d04fc112567e6839ee5aee02033c3e6ff5b0928c8149bb9eec54f0ea80f45789c4333a761f14ddb55a8401405d7cbeb853e68ed430a1702505558f22749e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/fc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-toml/-/eslint-plugin-toml-0.12.0.tgz",
+        "sha512": "fbfc1539b03d0d5870641d671bcdc3d8e01046b710657cbe76ba949c524aca6aa799b9db7e0fd43e610c08aac935c11ba141b152362b265832fbf63ddf499445",
+        "dest-filename": "1539b03d0d5870641d671bcdc3d8e01046b710657cbe76ba949c524aca6aa799b9db7e0fd43e610c08aac935c11ba141b152362b265832fbf63ddf499445",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/fc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-62.0.0.tgz",
+        "sha512": "1c89489062e4bdfdbd604892fc89ae0d941b3f5da05b2c798b70ba5eb47132f55da8cae8088f6aa15602a08975ec284df94f3da67f6c5702f18485a3e6711cee",
+        "dest-filename": "489062e4bdfdbd604892fc89ae0d941b3f5da05b2c798b70ba5eb47132f55da8cae8088f6aa15602a08975ec284df94f3da67f6c5702f18485a3e6711cee",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/89"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.3.0.tgz",
+        "sha512": "6450665cc18161f1edb5d46d386f67145a6652f32d6c74a3b0aad2db4bdd59d6df89562c3b7c80d92198cbd8bd5e66490df30605f9591810a6ef44849c542d38",
+        "dest-filename": "665cc18161f1edb5d46d386f67145a6652f32d6c74a3b0aad2db4bdd59d6df89562c3b7c80d92198cbd8bd5e66490df30605f9591810a6ef44849c542d38",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/50"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.6.2.tgz",
+        "sha512": "9c0e7252cfc1d4a98acef0b8d9fc83d3e97d61df8bb44a5585645b5ee0e3d1ef99511713b7245b303594789993021db00ba8c2f37ada4badda9cd336613dcd3f",
+        "dest-filename": "7252cfc1d4a98acef0b8d9fc83d3e97d61df8bb44a5585645b5ee0e3d1ef99511713b7245b303594789993021db00ba8c2f37ada4badda9cd336613dcd3f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/0e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-1.19.1.tgz",
+        "sha512": "6d890ec721225e1f56c5485560f10b7521f1186e693a309278939591f748ca3eadba21c3c6b112d96016d5d0719f789a6507b2e7b5df9702ed09845c34f3a23a",
+        "dest-filename": "0ec721225e1f56c5485560f10b7521f1186e693a309278939591f748ca3eadba21c3c6b112d96016d5d0719f789a6507b2e7b5df9702ed09845c34f3a23a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/89"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-processor-vue-blocks/-/eslint-processor-vue-blocks-2.0.0.tgz",
+        "sha512": "bb85b4089c06a166376e35c0b85a5cfdbe9e2b7350108f0ca1e5bbae2b4a8f71b7cff5ad1eb2a392a7fec24f263c4cb9ae53064be93a01960ec365c1a0dff4d9",
+        "dest-filename": "b4089c06a166376e35c0b85a5cfdbe9e2b7350108f0ca1e5bbae2b4a8f71b7cff5ad1eb2a392a7fec24f263c4cb9ae53064be93a01960ec365c1a0dff4d9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/85"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+        "sha512": "b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e",
+        "dest-filename": "ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/d5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+        "sha512": "c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a",
+        "dest-filename": "3e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/97"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+        "sha512": "521764e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25",
+        "dest-filename": "64e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/17"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+        "sha512": "2c4c9a9aa4bb5b91c1dee8c9caf8b41d02bf76d548359bdde66000a7d793e52fee8c1c868e264b0b33dc1d5cee5dba490c917f731c0795f71e5540d9da59d24f",
+        "dest-filename": "9a9aa4bb5b91c1dee8c9caf8b41d02bf76d548359bdde66000a7d793e52fee8c1c868e264b0b33dc1d5cee5dba490c917f731c0795f71e5540d9da59d24f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/4c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+        "sha512": "8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261",
+        "dest-filename": "c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/a3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+        "sha512": "a2bb99685923a2b4e9177da40d2239ffbe558b019e6608a7186cb636839283743d6e7c259e60e6e072e7925d111379fe9e30d7474dfb698d7ec79f19ff315dc1",
+        "dest-filename": "99685923a2b4e9177da40d2239ffbe558b019e6608a7186cb636839283743d6e7c259e60e6e072e7925d111379fe9e30d7474dfb698d7ec79f19ff315dc1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/bb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+        "sha512": "71af69c3d7e898570a3ef14b5e104a50af7466f1a26e218ebd124d6e396363bb3bbaaff960ee013b3718b49a84c5dc7df6b17a6807274711e67141dccfab10b2",
+        "dest-filename": "69c3d7e898570a3ef14b5e104a50af7466f1a26e218ebd124d6e396363bb3bbaaff960ee013b3718b49a84c5dc7df6b17a6807274711e67141dccfab10b2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/af"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+        "sha512": "2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a",
+        "dest-filename": "ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/67"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+        "sha512": "30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004",
+        "dest-filename": "4046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/c7"
     },
     {
         "type": "file",
@@ -622,6 +1420,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+        "sha512": "915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea",
+        "dest-filename": "1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/5b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+        "sha512": "2e60f17d65f071302b93c7d412739f499a47389eb338c50928eb452c5a892e82897adb901bcef851ceff2a48bbcc52f36326e6661a7533bfbdf297cca9e5fcc8",
+        "dest-filename": "f17d65f071302b93c7d412739f499a47389eb338c50928eb452c5a892e82897adb901bcef851ceff2a48bbcc52f36326e6661a7533bfbdf297cca9e5fcc8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2e/60"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+        "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+        "dest-filename": "90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/7a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+        "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+        "dest-filename": "7fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/17"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+        "sha512": "0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77",
+        "dest-filename": "eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0c/25"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+        "sha512": "5adc924e44b838a7afe49b691d79e26f81b18aeaf38793421af5ab15a677e26e897a17d3521299be7f678d37f0e3cb7a26e99540e9ab2aaa6619c770c6786a05",
+        "dest-filename": "924e44b838a7afe49b691d79e26f81b18aeaf38793421af5ab15a677e26e897a17d3521299be7f678d37f0e3cb7a26e99540e9ab2aaa6619c770c6786a05",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/dc"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
         "sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
         "dest-filename": "d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
@@ -629,10 +1469,269 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+        "sha512": "5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
+        "dest-filename": "d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/74"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+        "sha512": "69f7783bbce9a87791ca0e0f7c342c5e69437b63df747b49b7a024b7c8ce59a0292ce664e495ece95311dbd973d37a517bd9a9ca4ad1098218c5a25871fa6771",
+        "dest-filename": "783bbce9a87791ca0e0f7c342c5e69437b63df747b49b7a024b7c8ce59a0292ce664e495ece95311dbd973d37a517bd9a9ca4ad1098218c5a25871fa6771",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/f7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+        "sha512": "efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
+        "dest-filename": "cf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/cf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+        "sha512": "7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb",
+        "dest-filename": "1c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/b7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+        "sha512": "197fb2b30e0f042cf43f3a2c1c37a964600d12e14230bae7453884cbd31c1a39a409063046ae00fd7efce86fdf8ccffe3a3b16494d59ad8e6ac8045998efeec2",
+        "dest-filename": "b2b30e0f042cf43f3a2c1c37a964600d12e14230bae7453884cbd31c1a39a409063046ae00fd7efce86fdf8ccffe3a3b16494d59ad8e6ac8045998efeec2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/7f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+        "sha512": "c33b2003a58eabed3dc2b535b6c274f6e75e47f61945a780acbf5ed703db160dc61b6c839c2da574aa71b38c6e9e9145f4382a0aa388adaddb7351d6ac9dfb5b",
+        "dest-filename": "2003a58eabed3dc2b535b6c274f6e75e47f61945a780acbf5ed703db160dc61b6c839c2da574aa71b38c6e9e9145f4382a0aa388adaddb7351d6ac9dfb5b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c3/3b"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
         "sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
         "dest-filename": "037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/1a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+        "sha512": "d552936490b006bbdb77e5a7dc03a040fff602ff937d308e944e00711244ef65b592c6576c0c7c3cf051f51ce04de48fce53cc1eb6c034c1f72db96d1fbdf0c5",
+        "dest-filename": "936490b006bbdb77e5a7dc03a040fff602ff937d308e944e00711244ef65b592c6576c0c7c3cf051f51ce04de48fce53cc1eb6c034c1f72db96d1fbdf0c5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/52"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+        "sha512": "21a390f69b98b63ae4abb63462097d283667adffda89425852955ff3dcbc9326b16d11bb6354ab5ff8daba6aeff35bdceb5fa488c7a6a6e8ec337630ef0e6a73",
+        "dest-filename": "90f69b98b63ae4abb63462097d283667adffda89425852955ff3dcbc9326b16d11bb6354ab5ff8daba6aeff35bdceb5fa488c7a6a6e8ec337630ef0e6a73",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/a3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+        "sha512": "5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0",
+        "dest-filename": "08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/1c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+        "sha512": "a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5",
+        "dest-filename": "46bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/a8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+        "sha512": "ec00b24f7c26ca9dc8eb54b87c6ebcd8bd150364460fda2d92a189230354305d52594a266c8224f9a7f5ba7b83620326d3cd9a1d8c03fa6cc9beff48bbc76c82",
+        "dest-filename": "b24f7c26ca9dc8eb54b87c6ebcd8bd150364460fda2d92a189230354305d52594a266c8224f9a7f5ba7b83620326d3cd9a1d8c03fa6cc9beff48bbc76c82",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/00"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+        "sha512": "73f735e62dba56b278211b7967cf439c8cc21839fd11c79b89b8403a3c3989ba841ec135c0b52090f9fd44398d7142b253cec679a2fadf79f227ea6994547665",
+        "dest-filename": "35e62dba56b278211b7967cf439c8cc21839fd11c79b89b8403a3c3989ba841ec135c0b52090f9fd44398d7142b253cec679a2fadf79f227ea6994547665",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/f7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+        "sha512": "b872606f000cc0d15fe662ecb7b2162cd835e31d4291eaa09496ff2b77688b8770eaad88bc002633f63cd647afcbcdf03fe4acb7e9eeb454d838683777596cc6",
+        "dest-filename": "606f000cc0d15fe662ecb7b2162cd835e31d4291eaa09496ff2b77688b8770eaad88bc002633f63cd647afcbcdf03fe4acb7e9eeb454d838683777596cc6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/72"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+        "sha512": "45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+        "dest-filename": "79fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+        "sha512": "12d2b0a0eea4c422fd58ee718a98874d9952cc19bb58b4fadbb4ea0bfb9545dd072a6abc357c9e6e7358c43a018bbc2df1e4d6ad4aca5c2395685abdc759206a",
+        "dest-filename": "b0a0eea4c422fd58ee718a98874d9952cc19bb58b4fadbb4ea0bfb9545dd072a6abc357c9e6e7358c43a018bbc2df1e4d6ad4aca5c2395685abdc759206a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/d2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+        "sha512": "1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+        "dest-filename": "094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/29"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+        "sha512": "92283eacc9ff40e551bebedcf3a810f25597abe1e4bfa09b007d612eef911b7dfc4ad4e913c6746f8e120d56aa56eec718a7f6edfadd994604b3d853517fdc2d",
+        "dest-filename": "3eacc9ff40e551bebedcf3a810f25597abe1e4bfa09b007d612eef911b7dfc4ad4e913c6746f8e120d56aa56eec718a7f6edfadd994604b3d853517fdc2d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/28"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+        "sha512": "86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
+        "dest-filename": "53354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+        "sha512": "1ece7dc4135f508ba730581601b197e5cabaf3ddc86d68382a7ae36d8c17dedc74ceda2b5604c303a076b317fc7a31c9e30cfc06a194318967ccd05eaf936f1a",
+        "dest-filename": "7dc4135f508ba730581601b197e5cabaf3ddc86d68382a7ae36d8c17dedc74ceda2b5604c303a076b317fc7a31c9e30cfc06a194318967ccd05eaf936f1a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/ce"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+        "sha512": "4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9",
+        "dest-filename": "ca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/1d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "sha512": "2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+        "dest-filename": "cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/65"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+        "sha512": "9ba140a3fb299ac5b601bd9f537e494d8c2d38a6b6c80c174b08234afd53273878321ee60b797300e54b069adbef65ec4eb824108b25ed8ac53408838918481a",
+        "dest-filename": "40a3fb299ac5b601bd9f537e494d8c2d38a6b6c80c174b08234afd53273878321ee60b797300e54b069adbef65ec4eb824108b25ed8ac53408838918481a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/a1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
+        "sha512": "7f846a24a0547b9ad0909d9e2442415d2b62701de119b37d8f4cb1c4c405a885bcf49a7d59816dcdf4dc465b2d0ca5544d1cd23932ca45f3bdbc8ced7a7c2dc4",
+        "dest-filename": "6a24a0547b9ad0909d9e2442415d2b62701de119b37d8f4cb1c4c405a885bcf49a7d59816dcdf4dc465b2d0ca5544d1cd23932ca45f3bdbc8ced7a7c2dc4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/84"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+        "sha512": "49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1",
+        "dest-filename": "9b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+        "sha512": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
+        "dest-filename": "526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/e9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+        "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+        "dest-filename": "4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/7c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+        "sha512": "a90293e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0",
+        "dest-filename": "93e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/02"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz",
+        "sha512": "899f0175bf3895646e1876a645717230bd3baf6d6973006b2e41c4b8780463951b0a8b81c2fec40a49c344acec4085cc8aaa4fca6aad21ff130bfb2160a079af",
+        "dest-filename": "0175bf3895646e1876a645717230bd3baf6d6973006b2e41c4b8780463951b0a8b81c2fec40a49c344acec4085cc8aaa4fca6aad21ff130bfb2160a079af",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/9f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.10.0.tgz",
+        "sha512": "f8b7b1a1347262e8b988e8491a7d7737d65accbdb79c01c6917b1ad69fc2f327aaefd5917cb05a83a659d05406d9a46873dc9fa39f494fd118090a273a41ca91",
+        "dest-filename": "b1a1347262e8b988e8491a7d7737d65accbdb79c01c6917b1ad69fc2f327aaefd5917cb05a83a659d05406d9a46873dc9fa39f494fd118090a273a41ca91",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/b7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.0.0.tgz",
+        "sha512": "73b61ba24b2c3ce4879aa4db480993b675600156bfee5ba658d62aa2681de4a38cc8fad1bded9a9f1ea5a277ceb1711069ca85f45295523edb2e0e2f452bdd60",
+        "dest-filename": "1ba24b2c3ce4879aa4db480993b675600156bfee5ba658d62aa2681de4a38cc8fad1bded9a9f1ea5a277ceb1711069ca85f45295523edb2e0e2f452bdd60",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/b6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+        "sha512": "fec33774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868",
+        "dest-filename": "3774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/c3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+        "sha512": "e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+        "dest-filename": "7905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e1/b5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+        "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+        "dest-filename": "c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/b6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+        "sha512": "05d6e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f",
+        "dest-filename": "e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/d6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+        "sha512": "d5ee2aa118279f8e3ca51b8cbca1ac145ca6502aae655d26a4680ec8828d803dc95434ec549c910461ff166d2d05bf16b161a0981d660deebfc89310337ec350",
+        "dest-filename": "2aa118279f8e3ca51b8cbca1ac145ca6502aae655d26a4680ec8828d803dc95434ec549c910461ff166d2d05bf16b161a0981d660deebfc89310337ec350",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/ee"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+        "sha512": "a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+        "dest-filename": "4790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/15"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+        "sha512": "f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
+        "dest-filename": "f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/b4"
     },
     {
         "type": "file",
@@ -720,10 +1819,367 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+        "sha512": "6ab865c5b1519a8407977ddad199257bf616966370a32b7a40d64420972a35b76bb22c792ef7381f2c88dc49f0c53625658737d846d8ad0f12cc467b76a820f4",
+        "dest-filename": "65c5b1519a8407977ddad199257bf616966370a32b7a40d64420972a35b76bb22c792ef7381f2c88dc49f0c53625658737d846d8ad0f12cc467b76a820f4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/b8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+        "sha512": "88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553",
+        "dest-filename": "4ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/f6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+        "sha512": "d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321",
+        "dest-filename": "63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/aa"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+        "sha512": "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
+        "dest-filename": "0311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/69"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+        "sha512": "f518bea3425881e8536950410e832a225f065ed6d683bd753b7b2b7ed707859d1daa7113a8b6a820ad31d7b7d4c3dac54a52bfd0d96c29ed00861ca5e695c4da",
+        "dest-filename": "bea3425881e8536950410e832a225f065ed6d683bd753b7b2b7ed707859d1daa7113a8b6a820ad31d7b7d4c3dac54a52bfd0d96c29ed00861ca5e695c4da",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/18"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
         "sha512": "bddd85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609",
         "dest-filename": "85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/dd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+        "sha512": "c22633e3e26b2f26ff0ea5b6864149c4fed577b26e4c39bbedfbdb33c55f11076648ca9c22659e7916c7c198c18c81648bf55a30ad818458bba1451978ce5bab",
+        "dest-filename": "33e3e26b2f26ff0ea5b6864149c4fed577b26e4c39bbedfbdb33c55f11076648ca9c22659e7916c7c198c18c81648bf55a30ad818458bba1451978ce5bab",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/26"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+        "sha512": "4e6775560fe6dd7cf8dda7de3710c885646d15980cd952f269fe2f493630b9d4f27ae4e77a82f7aad58c0398de2f2cff3b5bc3266995e10b92705080dad04fc2",
+        "dest-filename": "75560fe6dd7cf8dda7de3710c885646d15980cd952f269fe2f493630b9d4f27ae4e77a82f7aad58c0398de2f2cff3b5bc3266995e10b92705080dad04fc2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/67"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+        "sha512": "b9985357ff0d06ec3458790f4eb0aa0ce974cd57b50489e0e59b47a03938f4c135aaa72362698b98e7f48042e0711331378c368ae21e56ca39ffa432992ae098",
+        "dest-filename": "5357ff0d06ec3458790f4eb0aa0ce974cd57b50489e0e59b47a03938f4c135aaa72362698b98e7f48042e0711331378c368ae21e56ca39ffa432992ae098",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/98"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+        "sha512": "2d1a88f7ec1d802db93f451120963dbf0a1c23309c92c76e1d0f4e1768e8c50a324cd55dbb02c0154ce3a28a6e4496c901179a2ab35028064a2f7b8232e81624",
+        "dest-filename": "88f7ec1d802db93f451120963dbf0a1c23309c92c76e1d0f4e1768e8c50a324cd55dbb02c0154ce3a28a6e4496c901179a2ab35028064a2f7b8232e81624",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/1a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+        "sha512": "e4754fd8c29a3fa2fe1ba61ac4f363b8bd013ebabda2b1b74ecad9f585db037bc3c3f002238304b27a03a67e99366ec69d982d01c38d2723e138ff2d34941abd",
+        "dest-filename": "4fd8c29a3fa2fe1ba61ac4f363b8bd013ebabda2b1b74ecad9f585db037bc3c3f002238304b27a03a67e99366ec69d982d01c38d2723e138ff2d34941abd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/75"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+        "sha512": "b2aa435a5b079fb01cf4635940c794ccf41233347a5afd1629136f4118342aa1e1d367e94f3ebd41cd504ac78d5f6f5b873d51388c8dcb11317dac152939b519",
+        "dest-filename": "435a5b079fb01cf4635940c794ccf41233347a5afd1629136f4118342aa1e1d367e94f3ebd41cd504ac78d5f6f5b873d51388c8dcb11317dac152939b519",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b2/aa"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+        "sha512": "98a29bf75e5317e382e69b63e5b27b58544f758b6e1efd324d1c4adad26f8be043a9b9221bb87bbbff5223cf6744061c99aa76c4740bf43f901bfeb04ab4ed5e",
+        "dest-filename": "9bf75e5317e382e69b63e5b27b58544f758b6e1efd324d1c4adad26f8be043a9b9221bb87bbbff5223cf6744061c99aa76c4740bf43f901bfeb04ab4ed5e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/98/a2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+        "sha512": "efc504bde6f3cffac92312ef13b66d0ddfef210d111effb7321e4347dea9edc4bb1ec0616082020c10aef1cb1335634eead0567ea5cf59e911ba3d8534e18e66",
+        "dest-filename": "04bde6f3cffac92312ef13b66d0ddfef210d111effb7321e4347dea9edc4bb1ec0616082020c10aef1cb1335634eead0567ea5cf59e911ba3d8534e18e66",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/c5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+        "sha512": "22bb6f36f8f10b5a34ead6810152739c49e4887c4b153ce0a2751dcbc873155783ba7d2e4e3c71ad119568d16a914d70251dd104f11fb31994ea30d63e87eb4d",
+        "dest-filename": "6f36f8f10b5a34ead6810152739c49e4887c4b153ce0a2751dcbc873155783ba7d2e4e3c71ad119568d16a914d70251dd104f11fb31994ea30d63e87eb4d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/22/bb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+        "sha512": "d2e95f75038cdf2b07842275a74ea5d1bd152a5854d30b90b37b61c5941a8237233eb94546a636d79b991871c96a7f461005ddf4c6df3e3149cfea8c91547acd",
+        "dest-filename": "5f75038cdf2b07842275a74ea5d1bd152a5854d30b90b37b61c5941a8237233eb94546a636d79b991871c96a7f461005ddf4c6df3e3149cfea8c91547acd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/e9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+        "sha512": "4ea202c32bc9269070bc600c6638f82769f45fc416a76d5bf65d28ede5f2549db960d5986c90d52320f56d95c4e96b55e9198a2556264002966b4cd6380073db",
+        "dest-filename": "02c32bc9269070bc600c6638f82769f45fc416a76d5bf65d28ede5f2549db960d5986c90d52320f56d95c4e96b55e9198a2556264002966b4cd6380073db",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/a2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+        "sha512": "c63ebcc0c4ef19754e2a89e6a20e8bc3224aad85d93ef97069b6abc938cb87d2eebe8bc1fca007fa4be2f068e3fbbac98ec162db79e4531450bf52aa4aba0ca8",
+        "dest-filename": "bcc0c4ef19754e2a89e6a20e8bc3224aad85d93ef97069b6abc938cb87d2eebe8bc1fca007fa4be2f068e3fbbac98ec162db79e4531450bf52aa4aba0ca8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/3e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+        "sha512": "d07e38bc38a69f9d45d18c2fc522529b47820ce25346598dd11d72061e072e3f70895d439f44285c66ef1405a3da1488b554e50a6045d61a8a948c9405514b3e",
+        "dest-filename": "38bc38a69f9d45d18c2fc522529b47820ce25346598dd11d72061e072e3f70895d439f44285c66ef1405a3da1488b554e50a6045d61a8a948c9405514b3e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/7e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+        "sha512": "44306b1c4312c5514b83ac6f9d799bd40cabd96ccb0168de4804c0a31c0a60957de1378d6af82821d0346bdcadcc3495cc1cb660a14af9e9823ce1226cb782ae",
+        "dest-filename": "6b1c4312c5514b83ac6f9d799bd40cabd96ccb0168de4804c0a31c0a60957de1378d6af82821d0346bdcadcc3495cc1cb660a14af9e9823ce1226cb782ae",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/30"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+        "sha512": "0b8024b8cddd039f1c81985aef3567b95c41843b1bb6d20c8b2b6382c3365db1c00767da4556874657b8d39e7c14137e0c972b2cd0a8a86e6696ba5d538711b6",
+        "dest-filename": "24b8cddd039f1c81985aef3567b95c41843b1bb6d20c8b2b6382c3365db1c00767da4556874657b8d39e7c14137e0c972b2cd0a8a86e6696ba5d538711b6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/80"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+        "sha512": "a0e83b927ce189c810dede100a309681399f361bd06c30e725e56ef6ff35afb365b4d0959a13f2d5f2515f6ee921269f7632fe495738777978f066faa5b472a7",
+        "dest-filename": "3b927ce189c810dede100a309681399f361bd06c30e725e56ef6ff35afb365b4d0959a13f2d5f2515f6ee921269f7632fe495738777978f066faa5b472a7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/e8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+        "sha512": "ff23e1c48d67b670cdb221edccb2989c4def7fd259e9c022b2a5436ae869e02107c656f8ba8393c4e089fbdb39d5b201f14d4dd4527545738a4c8943e41fe0ab",
+        "dest-filename": "e1c48d67b670cdb221edccb2989c4def7fd259e9c022b2a5436ae869e02107c656f8ba8393c4e089fbdb39d5b201f14d4dd4527545738a4c8943e41fe0ab",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/23"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+        "sha512": "003563a4e3a48f3d6186464b94189803d711d809dff05e07a9950ee9ee5e0dc3d07744f1c397f12f3cf19c491291f9c3d30ce24868afeec62193f92dbdb7f5bb",
+        "dest-filename": "63a4e3a48f3d6186464b94189803d711d809dff05e07a9950ee9ee5e0dc3d07744f1c397f12f3cf19c491291f9c3d30ce24868afeec62193f92dbdb7f5bb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/35"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+        "sha512": "b76394fdd5d78a8011ac2eb259f27886a07badcb75e1ef1fee6d1c6c8e615260f2c88970bf9bc4b68a29b47f083646cbcce6adccab956d098061c6d6a32cfa0e",
+        "dest-filename": "94fdd5d78a8011ac2eb259f27886a07badcb75e1ef1fee6d1c6c8e615260f2c88970bf9bc4b68a29b47f083646cbcce6adccab956d098061c6d6a32cfa0e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/63"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+        "sha512": "c479533a6b824a8b4803c4d6d660c833a5f63b54a25f93fd22e0eda86a2716110ad2a811238c9e0babccc44576760cabd93883fb63d0d74a3e70e85d5407307e",
+        "dest-filename": "533a6b824a8b4803c4d6d660c833a5f63b54a25f93fd22e0eda86a2716110ad2a811238c9e0babccc44576760cabd93883fb63d0d74a3e70e85d5407307e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/79"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+        "sha512": "a8805986ac6a23a7e32c36054c121ae1e8af0cc9cff8e66ab0dc26437c4d2c4e02c7073ecdf4047dbb3ab73028d878eaf9b87aab917e67cfdc92cacb15859043",
+        "dest-filename": "5986ac6a23a7e32c36054c121ae1e8af0cc9cff8e66ab0dc26437c4d2c4e02c7073ecdf4047dbb3ab73028d878eaf9b87aab917e67cfdc92cacb15859043",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/80"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+        "sha512": "bec280ad0b22726eedd33d86ba09022ad65e86a526df5a1e18157f2954a8ad64b2f1994d02fef2b63161bdaaf2522094258aacf8da04e80161a50bc14cce90e3",
+        "dest-filename": "80ad0b22726eedd33d86ba09022ad65e86a526df5a1e18157f2954a8ad64b2f1994d02fef2b63161bdaaf2522094258aacf8da04e80161a50bc14cce90e3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/c2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+        "sha512": "5deeab0dd2659266c5444c694ce9918fd37731a5a66c081da52ac142f085aa17b3527e001ea2476da1277db5586227b1552b3ffeda8e758fc3c618dd0a226720",
+        "dest-filename": "ab0dd2659266c5444c694ce9918fd37731a5a66c081da52ac142f085aa17b3527e001ea2476da1277db5586227b1552b3ffeda8e758fc3c618dd0a226720",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/ee"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+        "sha512": "54531e932404c6a216ef120285c5e7e28936f58137ae7bb2bde5b7c194165aa17836ff56939ae027df4accfbc78e498f5c5f7715721b069e98756dedef5ffb56",
+        "dest-filename": "1e932404c6a216ef120285c5e7e28936f58137ae7bb2bde5b7c194165aa17836ff56939ae027df4accfbc78e498f5c5f7715721b069e98756dedef5ffb56",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/53"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+        "sha512": "cd19318ed071c4b77649cd1df9f6e712e9ec4e3e3a4965e05dc899987ab49036069dc93f6521a3f7fc142d357de6ea1e6222b98515cfda627df14a3872afcb42",
+        "dest-filename": "318ed071c4b77649cd1df9f6e712e9ec4e3e3a4965e05dc899987ab49036069dc93f6521a3f7fc142d357de6ea1e6222b98515cfda627df14a3872afcb42",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/19"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+        "sha512": "e5b67edc28e101df5e0a16131ec8f2e931b1a4e1522a028a24f271af6f778d36dfaf2d8a0e85a48416fa4dc3d5078366cda3e132cd45ae6f40647ece0f80a3cf",
+        "dest-filename": "7edc28e101df5e0a16131ec8f2e931b1a4e1522a028a24f271af6f778d36dfaf2d8a0e85a48416fa4dc3d5078366cda3e132cd45ae6f40647ece0f80a3cf",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/b6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+        "sha512": "39bd27b99dcf2adfe7d213911f2be80fdb9986bf996bcb05a0ff8e9cc72758ae659e04b300b81060a32bf512553962ea418bb29faba5a865925ddc1fe85f3495",
+        "dest-filename": "27b99dcf2adfe7d213911f2be80fdb9986bf996bcb05a0ff8e9cc72758ae659e04b300b81060a32bf512553962ea418bb29faba5a865925ddc1fe85f3495",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/bd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+        "sha512": "c2ff2d7544c9ded8521451492ada5828e62218fdbebfde87be4e13bbc2a9080b1332ceb28be9d5986875b32bd20ac6b1cf8e49e896f0fbd0c3ea0f7bf8d57aed",
+        "dest-filename": "2d7544c9ded8521451492ada5828e62218fdbebfde87be4e13bbc2a9080b1332ceb28be9d5986875b32bd20ac6b1cf8e49e896f0fbd0c3ea0f7bf8d57aed",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/ff"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+        "sha512": "41434510e3c42df9afbfee3188d836b1161e4bf3fce294d6d130a03f9cdcf45a577ad1d8d1a6fb4b12b201008d09cd5e2b4e39f6ea0b235cb9a0ee5573575b84",
+        "dest-filename": "4510e3c42df9afbfee3188d836b1161e4bf3fce294d6d130a03f9cdcf45a577ad1d8d1a6fb4b12b201008d09cd5e2b4e39f6ea0b235cb9a0ee5573575b84",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/43"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+        "sha512": "2b4907ccce9a7d6fcc6de59858b8e81d0bf5b2083643d11c707103cd293188ffc469a80dcc29bb4ff58c299deb8cc6ef229bc189983047774a33282d038986d5",
+        "dest-filename": "07ccce9a7d6fcc6de59858b8e81d0bf5b2083643d11c707103cd293188ffc469a80dcc29bb4ff58c299deb8cc6ef229bc189983047774a33282d038986d5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2b/49"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+        "sha512": "3a70271fc5239b2e7d25cc99c3c2526caf5c1a9755638e0d2a048cec4f4487b0e22d2d84f513507f474e35a183cc41bdca3125e6172a788b23e217d190b1ff06",
+        "dest-filename": "271fc5239b2e7d25cc99c3c2526caf5c1a9755638e0d2a048cec4f4487b0e22d2d84f513507f474e35a183cc41bdca3125e6172a788b23e217d190b1ff06",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/70"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+        "sha512": "71c51b624e82c1576498240ccabeb8757cf8d847c71a43d09418f9a7b6151b3abc23b0ad8d7649aee6c061ecdfed1a7e6e33ec7a244ea9eec6e9fa0577e944bb",
+        "dest-filename": "1b624e82c1576498240ccabeb8757cf8d847c71a43d09418f9a7b6151b3abc23b0ad8d7649aee6c061ecdfed1a7e6e33ec7a244ea9eec6e9fa0577e944bb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/c5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+        "sha512": "9c357fefb163e9e1f5ca7c2c7184ceb1b2bbad1fff523d1b65707025945f68b109d6218147a9087cd9a536a6aa25feb8f443f417735635d7898b4dde96594d51",
+        "dest-filename": "7fefb163e9e1f5ca7c2c7184ceb1b2bbad1fff523d1b65707025945f68b109d6218147a9087cd9a536a6aa25feb8f443f417735635d7898b4dde96594d51",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/35"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+        "sha512": "737715c76cb82aa527c28a5c3bd6ff482768d8eebb2f0249fd4caa19f6e281a85f7a02fd9b2a041680d8660913edfdfa4f46cbaccf6165301a0321fe3c20178f",
+        "dest-filename": "15c76cb82aa527c28a5c3bd6ff482768d8eebb2f0249fd4caa19f6e281a85f7a02fd9b2a041680d8660913edfdfa4f46cbaccf6165301a0321fe3c20178f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/77"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+        "sha512": "d9c3448980e1096288f86b3d4f44e2cac935dfa4a7475de184ef325ba04637284e0b8a98167c05d6729f0f71c50085c0e5ce3946b206d6e6f5d46897798775c4",
+        "dest-filename": "448980e1096288f86b3d4f44e2cac935dfa4a7475de184ef325ba04637284e0b8a98167c05d6729f0f71c50085c0e5ce3946b206d6e6f5d46897798775c4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d9/c3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+        "sha512": "b313ea9a8ef42f201126cd30d947250023d4504aa5b42909e8f84a74c203b89de049ffd0fbf1887b758a9742236ff1b21fd94ea5491100edb0a7419590bbd2f5",
+        "dest-filename": "ea9a8ef42f201126cd30d947250023d4504aa5b42909e8f84a74c203b89de049ffd0fbf1887b758a9742236ff1b21fd94ea5491100edb0a7419590bbd2f5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b3/13"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+        "sha512": "55d432c455854f6fc51898304272586ded638d0a0d4d2e118e09664a34d496950c6bde47b71f4d1de616e2b1832736e3bc2b25f5e2e3310c0678496caa6cdc1e",
+        "dest-filename": "32c455854f6fc51898304272586ded638d0a0d4d2e118e09664a34d496950c6bde47b71f4d1de616e2b1832736e3bc2b25f5e2e3310c0678496caa6cdc1e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/d4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+        "sha512": "f4df48a2667f62e18665999079cd4c6e0c6d960a2e8314e8755c03cf3128b8f2a8dea156bf29851d67270e2dafcd5d5f7fa91ab3db9c5bea37cb324af5807501",
+        "dest-filename": "48a2667f62e18665999079cd4c6e0c6d960a2e8314e8755c03cf3128b8f2a8dea156bf29851d67270e2dafcd5d5f7fa91ab3db9c5bea37cb324af5807501",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/df"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+        "sha512": "5d02eee79da249cb6f9c47205f0ebe4b1ef919f9403cd103d6ac7b78127ec327416f62826d165ef8dc2f20410c33cdee9a5d7ed96497a4101ca7d2140a009858",
+        "dest-filename": "eee79da249cb6f9c47205f0ebe4b1ef919f9403cd103d6ac7b78127ec327416f62826d165ef8dc2f20410c33cdee9a5d7ed96497a4101ca7d2140a009858",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/02"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+        "sha512": "bece6df00a5ab9df4ddbc9200ab45474479de1427ec1636f89c1cb3f109af4436562e018df5334113cb9cb5bc0df762834f0c54e08446e787a79f684f21e31d1",
+        "dest-filename": "6df00a5ab9df4ddbc9200ab45474479de1427ec1636f89c1cb3f109af4436562e018df5334113cb9cb5bc0df762834f0c54e08446e787a79f684f21e31d1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/ce"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+        "sha512": "630d04092a49a15885d6a4d4e030ba370b42e1a586b75124cda401f0a3cfc82451f33f5359e5741db1051933be658d70076db39b19c9aa13f24e93950a97874c",
+        "dest-filename": "04092a49a15885d6a4d4e030ba370b42e1a586b75124cda401f0a3cfc82451f33f5359e5741db1051933be658d70076db39b19c9aa13f24e93950a97874c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/0d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+        "sha512": "ce97bdf10ea4bdabe90abd4d3d548231e6c229f0fb080d8da99fabca478d84e348241a5cd6d14ab7d86e70b1b085ade3353348f251e972d5895a88a6545e0f7c",
+        "dest-filename": "bdf10ea4bdabe90abd4d3d548231e6c229f0fb080d8da99fabca478d84e348241a5cd6d14ab7d86e70b1b085ade3353348f251e972d5895a88a6545e0f7c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ce/97"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+        "sha512": "27ba7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f",
+        "dest-filename": "7ade1462023c35343130c355bb8b7efe07222b3963b95d0400cd9dd539c2f43cdc9bc297e657f374e73140cf043d512c84717eaddd43be2b96aa0503881f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/ba"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+        "sha512": "1ba4f4657e3cc60a33c7be7cee4a1e5fd62cd8d632e869affff3fcf6c12d7bd57dc2121aa4c345e2274ac675b642d09c2e24d695bff07c269b02d0055a1841a3",
+        "dest-filename": "f4657e3cc60a33c7be7cee4a1e5fd62cd8d632e869affff3fcf6c12d7bd57dc2121aa4c345e2274ac675b642d09c2e24d695bff07c269b02d0055a1841a3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1b/a4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+        "sha512": "97c0fd38349158b7b628725289f586c01aa94d95c85d37a8f2694a8d8f84d8701a91a4de369a80c8167c192a8bcc7830e17987982f3086fa6324d31b15937bfe",
+        "dest-filename": "fd38349158b7b628725289f586c01aa94d95c85d37a8f2694a8d8f84d8701a91a4de369a80c8167c192a8bcc7830e17987982f3086fa6324d31b15937bfe",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+        "sha512": "e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+        "dest-filename": "73b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/59"
     },
     {
         "type": "file",
@@ -741,10 +2197,122 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+        "sha512": "396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b",
+        "dest-filename": "43f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/63"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz",
+        "sha512": "90a1c9871c2947f3a4c9ccf81e140a2a58567b801211f3e091258d98a14777bf9ecee425c6403970cdfe5e404fbe6d609877a7df0e77aac600bfef06c11ac196",
+        "dest-filename": "c9871c2947f3a4c9ccf81e140a2a58567b801211f3e091258d98a14777bf9ecee425c6403970cdfe5e404fbe6d609877a7df0e77aac600bfef06c11ac196",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/a1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+        "sha512": "9e687794291867782b66fa9c087f9f8e643b5fe1f439e6603f8d0e89eac4680a6d5f85e87cc87993035b5a1ee505db94cc2715ffc919f8d0cb0b09b68a8ac894",
+        "dest-filename": "7794291867782b66fa9c087f9f8e643b5fe1f439e6603f8d0e89eac4680a6d5f85e87cc87993035b5a1ee505db94cc2715ffc919f8d0cb0b09b68a8ac894",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9e/68"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+        "sha512": "96a8eb8e668ea009d67cc9813cbf97367ca7661dbeb30c625f7594134b38c841c8ea6f80c2b2b65193a2988465dd7ff841cb55a92f008998c5ab2386acc5dbff",
+        "dest-filename": "eb8e668ea009d67cc9813cbf97367ca7661dbeb30c625f7594134b38c841c8ea6f80c2b2b65193a2988465dd7ff841cb55a92f008998c5ab2386acc5dbff",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/a8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
+        "sha512": "dc30b750ca5e7df2d31e2b974b2fd41b834e2184cb958f6edd5f36f9d8d208b602956a1b6624b88af633a48516ad163f9dfb09f1c5ac2b21b741fc8b78f9a1be",
+        "dest-filename": "b750ca5e7df2d31e2b974b2fd41b834e2184cb958f6edd5f36f9d8d208b602956a1b6624b88af633a48516ad163f9dfb09f1c5ac2b21b741fc8b78f9a1be",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/30"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+        "sha512": "e88a50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6",
+        "dest-filename": "50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/8a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+        "sha512": "4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+        "dest-filename": "9a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/83"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+        "sha512": "2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f",
+        "dest-filename": "63b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/a3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+        "sha512": "eb50394e1a138831bf0bcb3c50c6704a8ac01b0309d044551a3d8e8e85b9a406a5b0d3a0d79fa24223f3acb2788e16751c9ce60b63c81d3da81221f74797f334",
+        "dest-filename": "394e1a138831bf0bcb3c50c6704a8ac01b0309d044551a3d8e8e85b9a406a5b0d3a0d79fa24223f3acb2788e16751c9ce60b63c81d3da81221f74797f334",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/50"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+        "sha512": "190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
+        "dest-filename": "84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/0d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz",
+        "sha512": "46656e0875ac7eed103cd5be9ab6b187fc63415c3f96150252bbbc6678b70adab7028321a434ead0e55d292ea27ac77a2aa6fbbe2095de2b002f8ddd722392a2",
+        "dest-filename": "6e0875ac7eed103cd5be9ab6b187fc63415c3f96150252bbbc6678b70adab7028321a434ead0e55d292ea27ac77a2aa6fbbe2095de2b002f8ddd722392a2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/65"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+        "sha512": "e2ceaf77a771d40a2d0b1fd1088da6eedec60a1e5b0d152d18dbd17c748fdb06c141d322ebba4f7bb9adce683071a43c54a2bfe8807b1a57f2bb7a9d6493f26d",
+        "dest-filename": "af77a771d40a2d0b1fd1088da6eedec60a1e5b0d152d18dbd17c748fdb06c141d322ebba4f7bb9adce683071a43c54a2bfe8807b1a57f2bb7a9d6493f26d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/ce"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+        "sha512": "1e5b3261d3019db3d0f49aff560275605e2c72795dbc9a49c42571e8a82a3cbe1dc69a6c5ab247088231417309aea1a7b1190d3c04db78c27c631bbb24cb1870",
+        "dest-filename": "3261d3019db3d0f49aff560275605e2c72795dbc9a49c42571e8a82a3cbe1dc69a6c5ab247088231417309aea1a7b1190d3c04db78c27c631bbb24cb1870",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/5b"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
         "sha512": "6fbba8d9409439865c9c5ff7203d25ba53898bf6da7f16b5c4f7bb64fb1a9a6052a634964248cdc65b7adf96064b632247d1a3bee5c2b73d9e9abde36eccfdf2",
         "dest-filename": "a8d9409439865c9c5ff7203d25ba53898bf6da7f16b5c4f7bb64fb1a9a6052a634964248cdc65b7adf96064b632247d1a3bee5c2b73d9e9abde36eccfdf2",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/bb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+        "sha512": "6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
+        "dest-filename": "50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/4f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+        "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+        "dest-filename": "9e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/39"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+        "sha512": "5948c6700a8fd6041a72841ef8e049b0503b2dde03c97b9422367971cef970b1ef27b76d36c4ee8298712000f0b294be02b68051e3c22ab495b4f2c58ff17cf3",
+        "dest-filename": "c6700a8fd6041a72841ef8e049b0503b2dde03c97b9422367971cef970b1ef27b76d36c4ee8298712000f0b294be02b68051e3c22ab495b4f2c58ff17cf3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/48"
     },
     {
         "type": "file",
@@ -762,6 +2330,41 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+        "sha512": "fc99b933846fb4115590a591bb604b51334ff3f3366be530b805fe69ee3bef4ab5a951ad7e31be5930aea68662c689239878abcbcb88f9d958f0a5d85791d555",
+        "dest-filename": "b933846fb4115590a591bb604b51334ff3f3366be530b805fe69ee3bef4ab5a951ad7e31be5930aea68662c689239878abcbcb88f9d958f0a5d85791d555",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/99"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+        "sha512": "488a82cc3460d2cf67a4ee57437b4d662a11635b8ad3a940e35ca7042d589854e69d8e858d48d5b7ab382e80039b0a22835aaa0f4a0af21d69ffc9a5331f0e8a",
+        "dest-filename": "82cc3460d2cf67a4ee57437b4d662a11635b8ad3a940e35ca7042d589854e69d8e858d48d5b7ab382e80039b0a22835aaa0f4a0af21d69ffc9a5331f0e8a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/48/8a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+        "sha512": "35cdc84f9c87cdf9537db8e0a967023e9a3b0da2b2e059e907497fcc2016d1373b8f1022baa4b11dab27b41dc3efcf3b2d2ac0f7790327d217a2fc49631c8b08",
+        "dest-filename": "c84f9c87cdf9537db8e0a967023e9a3b0da2b2e059e907497fcc2016d1373b8f1022baa4b11dab27b41dc3efcf3b2d2ac0f7790327d217a2fc49631c8b08",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/cd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.4.3.tgz",
+        "sha512": "43c077496bae212cbf0a26a0e0314fecc0ab257d3bc1f69e91ca83da8fe6b1d223e31f109776d9fcd10a39757b993561ee6d5876215688c8bdc47fb4cee1061f",
+        "dest-filename": "77496bae212cbf0a26a0e0314fecc0ab257d3bc1f69e91ca83da8fe6b1d223e31f109776d9fcd10a39757b993561ee6d5876215688c8bdc47fb4cee1061f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+        "sha512": "a2b46cb98a49570f0b740c2aa8bca4063f5e712e7f7111e5239fa7bd3a3c2dc08a9b30e6a953915ed388604110b8bf43e01c6d035966e62b00ab34190a843a12",
+        "dest-filename": "6cb98a49570f0b740c2aa8bca4063f5e712e7f7111e5239fa7bd3a3c2dc08a9b30e6a953915ed388604110b8bf43e01c6d035966e62b00ab34190a843a12",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/b4"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
         "sha512": "dd86e2d6d02ec003fdb34af5510d89e27e58d06d396c99295083b4fdb23d321c260fbd12e5a4d66d7181c311eb7a54fe5ccd64e9d334a64f92c0d9294d137b3e",
         "dest-filename": "e2d6d02ec003fdb34af5510d89e27e58d06d396c99295083b4fdb23d321c260fbd12e5a4d66d7181c311eb7a54fe5ccd64e9d334a64f92c0d9294d137b3e",
@@ -769,17 +2372,122 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.2.8.tgz",
-        "sha512": "f302a286517a10317c82b8a6c1dec63ce84b9109122208fa1e5729d025e1b4edc701779452a8606662669f4ece17c7b83db4eeb0c5fa6319b2d41a6d55166c77",
-        "dest-filename": "a286517a10317c82b8a6c1dec63ce84b9109122208fa1e5729d025e1b4edc701779452a8606662669f4ece17c7b83db4eeb0c5fa6319b2d41a6d55166c77",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/02"
+        "url": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+        "sha512": "be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6",
+        "dest-filename": "033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/47"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.52.tgz",
-        "sha512": "1db9e9963b9ef8984c26b94e8d0d62c69f667bbb1479cece8c5bd2f80d509bc93c5f2c66c37661c45bbb2e54975b5b3d017dcf384f56f68da8a8211e479b839a",
-        "dest-filename": "e9963b9ef8984c26b94e8d0d62c69f667bbb1479cece8c5bd2f80d509bc93c5f2c66c37661c45bbb2e54975b5b3d017dcf384f56f68da8a8211e479b839a",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1d/b9"
+        "url": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+        "sha512": "bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+        "dest-filename": "7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/8b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+        "sha512": "0227d3ed011b5bd36b8b8b40c11e4cfeece906ea9f65ffb3c1a10cfd09331238fb341b850f6ac1bb2d0addd13ef3096d6decc357b24c03459f9c23d845261b5c",
+        "dest-filename": "d3ed011b5bd36b8b8b40c11e4cfeece906ea9f65ffb3c1a10cfd09331238fb341b850f6ac1bb2d0addd13ef3096d6decc357b24c03459f9c23d845261b5c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/27"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+        "sha512": "27cae7eafe0305bda79c5aa4ab0cbafcd9d360c7202c0fac2ebd2220ee35aa9bf49fe9e06fb92c6a0dad3119748a76f56db3bf7ac530cd6d6f6c98bb2b4b08d2",
+        "dest-filename": "e7eafe0305bda79c5aa4ab0cbafcd9d360c7202c0fac2ebd2220ee35aa9bf49fe9e06fb92c6a0dad3119748a76f56db3bf7ac530cd6d6f6c98bb2b4b08d2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/ca"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+        "sha512": "b19bb3d5d616fd9b1f1b5ed64801bb792f39af96b4743b2f83eec18a2611e68ea528202d52b13076646668617aaf0563dcb72601e6243962843e56cfccddd8dc",
+        "dest-filename": "b3d5d616fd9b1f1b5ed64801bb792f39af96b4743b2f83eec18a2611e68ea528202d52b13076646668617aaf0563dcb72601e6243962843e56cfccddd8dc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/9b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+        "sha512": "8844f1a632ba628456246e68ea15cbc2f8d80285be144667f68b343c3fdbe803fac50c2c6bf63b942560222c416d43cc7e1bbe8b62ed75e02a5538069506ab7c",
+        "dest-filename": "f1a632ba628456246e68ea15cbc2f8d80285be144667f68b343c3fdbe803fac50c2c6bf63b942560222c416d43cc7e1bbe8b62ed75e02a5538069506ab7c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/44"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
+        "sha512": "359419742e70384fc7dd44f6f1f5462fe8a4399704cdf30693f73788df541b1cd61cc6b5a29ef6ef8a3289456b006e01d84b8586eb3c4af91a62786f5bdda9f5",
+        "dest-filename": "19742e70384fc7dd44f6f1f5462fe8a4399704cdf30693f73788df541b1cd61cc6b5a29ef6ef8a3289456b006e01d84b8586eb3c4af91a62786f5bdda9f5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/94"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+        "sha512": "c84eca51f16f68117318fb391f73a9b3545ebdf504b03739233eb9acec16838944f0725262d95eefbbae977fb9ef7e39ee81ef04ab8760397fc6a5242a910477",
+        "dest-filename": "ca51f16f68117318fb391f73a9b3545ebdf504b03739233eb9acec16838944f0725262d95eefbbae977fb9ef7e39ee81ef04ab8760397fc6a5242a910477",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/4e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+        "sha512": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
+        "dest-filename": "cc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/bf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+        "sha512": "b1e4b64e3dba4c154e0b6348736ace7b6cb664eede7f1213b4b65c1923a71c734e43b0a489405fc34230d9c93ac642213f02e128d2d2f013be844a6781096acf",
+        "dest-filename": "b64e3dba4c154e0b6348736ace7b6cb664eede7f1213b4b65c1923a71c734e43b0a489405fc34230d9c93ac642213f02e128d2d2f013be844a6781096acf",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/e4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.3.0.tgz",
+        "sha512": "e612393422702811adcd6b5d281ddcd9f384a48efb21a6b4cf8992cd93d4d5c27f3aaac66c569f9bdd1e75509ded3f529f3f92874f53300bf8110ab254bcee12",
+        "dest-filename": "393422702811adcd6b5d281ddcd9f384a48efb21a6b4cf8992cd93d4d5c27f3aaac66c569f9bdd1e75509ded3f529f3f92874f53300bf8110ab254bcee12",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/12"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.53.tgz",
+        "sha512": "41df5cda9d172997604f901877e2a000c82027c6660acdc99d2f4f4cc5a4c947ed78a95f98ab7125b5931e455a931c17b3551bee3ad1615785785ecdd2c431cb",
+        "dest-filename": "5cda9d172997604f901877e2a000c82027c6660acdc99d2f4f4cc5a4c947ed78a95f98ab7125b5931e455a931c17b3551bee3ad1615785785ecdd2c431cb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/df"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+        "sha512": "dc0eac0f45983fbf90ae36df340d8537716c39a1861687a4095813cb2a72e7780fc616e40888ed3ba61681dadf33e9fff2c23c25e5d9388c6c1e33133714389d",
+        "dest-filename": "ac0f45983fbf90ae36df340d8537716c39a1861687a4095813cb2a72e7780fc616e40888ed3ba61681dadf33e9fff2c23c25e5d9388c6c1e33133714389d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/0e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+        "sha512": "49db0a32b23d4dd823770794491f4cc1e1c0e0427c6311e7f0315a0e2b2f85595439ee01175b4b0fb1808f4948a96565f9d3dbfeb131af406d6f2e65a109b6d1",
+        "dest-filename": "0a32b23d4dd823770794491f4cc1e1c0e0427c6311e7f0315a0e2b2f85595439ee01175b4b0fb1808f4948a96565f9d3dbfeb131af406d6f2e65a109b6d1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/db"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+        "sha512": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+        "dest-filename": "6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/7c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+        "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+        "dest-filename": "9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/ef"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+        "sha512": "6cb186951d50c417329e7d9de589835f83068e566fcb631104344d1cb27c548ea5ebef45522c9314d27422f78e48fd1b7178150cf45c7c6a80d298daa94a5f56",
+        "dest-filename": "86951d50c417329e7d9de589835f83068e566fcb631104344d1cb27c548ea5ebef45522c9314d27422f78e48fd1b7178150cf45c7c6a80d298daa94a5f56",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/b1"
     },
     {
         "type": "file",
@@ -790,10 +2498,101 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+        "sha512": "3e2538dabfb13b851b512d5bba8dcb3c992394eef8df45e7e5254085da73cec3c7b236d855f9679c57404e069b9cbb9d7be0aabb6e69e8dfa0da5c3f3c5b1ae3",
+        "dest-filename": "38dabfb13b851b512d5bba8dcb3c992394eef8df45e7e5254085da73cec3c7b236d855f9679c57404e069b9cbb9d7be0aabb6e69e8dfa0da5c3f3c5b1ae3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3e/25"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+        "sha512": "0a5c9ae492228ffec2e9b451db6fad9c65db73854a9626ca4958f6887bd5797e62316eecd5221096abbaf7d26438324922187fa54bbc2f4fd52e1f317e50fe2d",
+        "dest-filename": "9ae492228ffec2e9b451db6fad9c65db73854a9626ca4958f6887bd5797e62316eecd5221096abbaf7d26438324922187fa54bbc2f4fd52e1f317e50fe2d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0a/5c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+        "sha512": "e0f453e2787510898f6edda301238a1d7ecf07b23e7b821634bbe42850f13612657e36d8965798421dbce59ff798f4c74802bf02f74c9b0e4134db981fc4a181",
+        "dest-filename": "53e2787510898f6edda301238a1d7ecf07b23e7b821634bbe42850f13612657e36d8965798421dbce59ff798f4c74802bf02f74c9b0e4134db981fc4a181",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/f4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+        "sha512": "4a5c91a1291d8757583f43f37252c4eebd0cf6c81b14a28c157a4545430db8a85049b0ba550206ceadc4d2ab1fbc625a50524f1afe96b35359fe16930237db30",
+        "dest-filename": "91a1291d8757583f43f37252c4eebd0cf6c81b14a28c157a4545430db8a85049b0ba550206ceadc4d2ab1fbc625a50524f1afe96b35359fe16930237db30",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/5c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+        "sha512": "e9f3dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a",
+        "dest-filename": "dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/f3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+        "sha512": "aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+        "dest-filename": "80bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/90"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+        "sha512": "31e413035af4962b4b51fd11a7f8a2b0268bf3beb594a0191da8a695b18ae23d07cac0b83cb7eaca0423f6cadcb349b645db4362717c52e6322a96e31d8a7b27",
+        "dest-filename": "13035af4962b4b51fd11a7f8a2b0268bf3beb594a0191da8a695b18ae23d07cac0b83cb7eaca0423f6cadcb349b645db4362717c52e6322a96e31d8a7b27",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/e4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+        "sha512": "83d963662c248bf2dfc664000ceddd118d426e99974f91e6d9f27e41a18ac125d4ca53326de3d1effebb616ee33abaef8c480bd459b3e64cf202359558b96e72",
+        "dest-filename": "63662c248bf2dfc664000ceddd118d426e99974f91e6d9f27e41a18ac125d4ca53326de3d1effebb616ee33abaef8c480bd459b3e64cf202359558b96e72",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/d9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+        "sha512": "5bf29893e3458649ac629b87ab92729278223829f17952fcbfc7459eac520fca8411d45f5e4d520cce89ccda9c1116dc1988fdb4cac3401615f5c8e09ee9c522",
+        "dest-filename": "9893e3458649ac629b87ab92729278223829f17952fcbfc7459eac520fca8411d45f5e4d520cce89ccda9c1116dc1988fdb4cac3401615f5c8e09ee9c522",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5b/f2"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
         "sha512": "8f666ae0dc90606e573124f871bb34d8093c88951dc513345c8e50cb15ee64ecca3883665aeae9dec997bb7cb9c03709ae9b70a528e05c7cc8431474a265e58d",
         "dest-filename": "6ae0dc90606e573124f871bb34d8093c88951dc513345c8e50cb15ee64ecca3883665aeae9dec997bb7cb9c03709ae9b70a528e05c7cc8431474a265e58d",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/66"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+        "sha512": "e35c09caf29ea77c93dadc8fa97ff86e571fc9b927181e03fa811328bb3b43be9488fa91a5424ade1af59f17a5c983b43c7295cc9c25bb468278402c188eaba7",
+        "dest-filename": "09caf29ea77c93dadc8fa97ff86e571fc9b927181e03fa811328bb3b43be9488fa91a5424ade1af59f17a5c983b43c7295cc9c25bb468278402c188eaba7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/5c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.10.1.tgz",
+        "sha512": "f668f2ddfae18a81885467306a6955954c89f71f961f0fd35e2cfd47860e966b08b81378debf43a7c1d9df9485f442a31eb9f7054663d38085f98a99da827eef",
+        "dest-filename": "f2ddfae18a81885467306a6955954c89f71f961f0fd35e2cfd47860e966b08b81378debf43a7c1d9df9485f442a31eb9f7054663d38085f98a99da827eef",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/68"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+        "sha512": "09481364bd62af0f2edbd6f3ace0ff9c7f398eac9cef80fa4ac84582e8ce200ee8b26d91cfb7581fbeda824c7b1f81413710eaec28dff888da5fff33c055be65",
+        "dest-filename": "1364bd62af0f2edbd6f3ace0ff9c7f398eac9cef80fa4ac84582e8ce200ee8b26d91cfb7581fbeda824c7b1f81413710eaec28dff888da5fff33c055be65",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/48"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+        "sha512": "103c860301f580ed00bac9bd815e93da752f0605d3e641a808c24f96539aa2867ee15bc988a05d644ef02b5f0dd5d784a3085c529b52fb919764af14fdfbe9c0",
+        "dest-filename": "860301f580ed00bac9bd815e93da752f0605d3e641a808c24f96539aa2867ee15bc988a05d644ef02b5f0dd5d784a3085c529b52fb919764af14fdfbe9c0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/3c"
     },
     {
         "type": "file",
@@ -804,10 +2603,24 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+        "sha512": "5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
+        "dest-filename": "94a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/57"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
         "sha512": "8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
         "dest-filename": "6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
         "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8e/5d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+        "sha512": "f5ae3fbb1953589e3e6b98b4a28735ad4ec2ed83b0df04fe506a9d78d3475a7385f6a70c0602d14bee08614a9b7337b0171e262c48a0ea06b087b5fa98594490",
+        "dest-filename": "3fbb1953589e3e6b98b4a28735ad4ec2ed83b0df04fe506a9d78d3475a7385f6a70c0602d14bee08614a9b7337b0171e262c48a0ea06b087b5fa98594490",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/ae"
     },
     {
         "type": "file",
@@ -818,6 +2631,55 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+        "sha512": "2ec8882dbb41113903cfc23da75750d2ec91516b9a43377f72e11e4b5868452c96e44e571a64f39706353ab373cda906a3023d0ebfc8f0755ac38853b67c72f2",
+        "dest-filename": "882dbb41113903cfc23da75750d2ec91516b9a43377f72e11e4b5868452c96e44e571a64f39706353ab373cda906a3023d0ebfc8f0755ac38853b67c72f2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2e/c8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+        "sha512": "d00495d3a000a0a083912dbec70e515c9cb0aeebaba5b0b82594a6ee7afb30eb75a23033bf2c9a3be53165fd7c8fc14217a926cc264a70080dff2bb6826d9781",
+        "dest-filename": "95d3a000a0a083912dbec70e515c9cb0aeebaba5b0b82594a6ee7afb30eb75a23033bf2c9a3be53165fd7c8fc14217a926cc264a70080dff2bb6826d9781",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/04"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+        "sha512": "828875b354c1aea4aaba449cf30ae3c1684bd21889c6003c9b8905c46950fbc1584370bf9b5d45713b386187a6ed5ebae0084756f82840b93cf744ac76caf621",
+        "dest-filename": "75b354c1aea4aaba449cf30ae3c1684bd21889c6003c9b8905c46950fbc1584370bf9b5d45713b386187a6ed5ebae0084756f82840b93cf744ac76caf621",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/88"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+        "sha512": "311d38baf0fed3b73097fca156e55602dc3edc6391fe49e52f9e4d77fc0075b964dbb18256dde5aa94e2bf2fed909719a0d3f34f04b563e28ca2394b0e1a13ce",
+        "dest-filename": "38baf0fed3b73097fca156e55602dc3edc6391fe49e52f9e4d77fc0075b964dbb18256dde5aa94e2bf2fed909719a0d3f34f04b563e28ca2394b0e1a13ce",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/1d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+        "sha512": "26cd26f5cc7ea8e803c68d1e32214612e796cedcfe778f8cdeb1a598a3d3f93e084bf8cfe32970dcdc29bba7294d33fc4753000b5905e156dd2eddc045fdb4f7",
+        "dest-filename": "26f5cc7ea8e803c68d1e32214612e796cedcfe778f8cdeb1a598a3d3f93e084bf8cfe32970dcdc29bba7294d33fc4753000b5905e156dd2eddc045fdb4f7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/cd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+        "sha512": "eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+        "dest-filename": "94cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+        "sha512": "10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+        "dest-filename": "f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/f0"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
         "sha512": "fc1a5d4b1fb20901a70af79c6f25ddc470e4ba4e79fc6df1c270b41aa6388264378fe03e83c933ce0078364fd220d8ea9fafb06aac371206d517640a131911c5",
         "dest-filename": "5d4b1fb20901a70af79c6f25ddc470e4ba4e79fc6df1c270b41aa6388264378fe03e83c933ce0078364fd220d8ea9fafb06aac371206d517640a131911c5",
@@ -825,47 +2687,290 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.5.tgz",
-        "sha512": "2ff1bd2148ce5a1054d32ba7f3daeff1f2aa98a0be4f41df86b1639489a5ef55a97c1bfd79be04f417aff0531bcae781214f6fc50a9b77ea0eb157036b96a61b",
-        "dest-filename": "bd2148ce5a1054d32ba7f3daeff1f2aa98a0be4f41df86b1639489a5ef55a97c1bfd79be04f417aff0531bcae781214f6fc50a9b77ea0eb157036b96a61b",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/f1"
+        "url": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz",
+        "sha512": "0b2754bc5390283f76f14cd9853a78a6bdaf5b3d4bf87f7db7b3e4967d9048f76f994453d0ca02e3051c71f0a7b846a284db2ef5a618ca4f9b7a9f2b95f9145f",
+        "dest-filename": "54bc5390283f76f14cd9853a78a6bdaf5b3d4bf87f7db7b3e4967d9048f76f994453d0ca02e3051c71f0a7b846a284db2ef5a618ca4f9b7a9f2b95f9145f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/27"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.5.tgz",
-        "sha512": "b0e56190eec3d256fefd3359be67ef0e58979dca8329adf33039042b615dd77279bea28ab841d265e62b6586084afd51213f3ca49445ff403a8089ca86b28ba9",
-        "dest-filename": "6190eec3d256fefd3359be67ef0e58979dca8329adf33039042b615dd77279bea28ab841d265e62b6586084afd51213f3ca49445ff403a8089ca86b28ba9",
-        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/e5"
+        "url": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+        "sha512": "1f3f6ae6c6b7dd885dba0970cfa83db244fc3813e28bee1b167f3cc3a27e27831f128e0a451a6688d1bf8471e475b44594b04eab137ccbc81fd856f431352056",
+        "dest-filename": "6ae6c6b7dd885dba0970cfa83db244fc3813e28bee1b167f3cc3a27e27831f128e0a451a6688d1bf8471e475b44594b04eab137ccbc81fd856f431352056",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/3f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.8.tgz",
+        "sha512": "75e2a0c31e9ec481de67017ad353f592d64a345d1b7a96923788c153702c6e574fc7d832954735243c58a6997cdb2c6090081acf46342c22ce8be7177bd1cc60",
+        "dest-filename": "a0c31e9ec481de67017ad353f592d64a345d1b7a96923788c153702c6e574fc7d832954735243c58a6997cdb2c6090081acf46342c22ce8be7177bd1cc60",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/e2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
+        "sha512": "60b55d82fd8ad77589ea7fa40f9a307a12ad117c1dc17ba3d934f224cb0eee949e2b0d9b7d13591a3841ed8ceba5b3188f96f942c51e6c7a4ea91dd1df38b2fe",
+        "dest-filename": "5d82fd8ad77589ea7fa40f9a307a12ad117c1dc17ba3d934f224cb0eee949e2b0d9b7d13591a3841ed8ceba5b3188f96f942c51e6c7a4ea91dd1df38b2fe",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/b5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+        "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+        "dest-filename": "374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+        "sha512": "04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970",
+        "dest-filename": "b607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/dd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+        "sha512": "2023f67be8ec1ef023d84da5207c5ae6d8d7465283268e0876f3ef0976d740677349f992a4d57220a32fa191e30d8f433f4cd5d7b888f39a3dd2f4455cd71c47",
+        "dest-filename": "f67be8ec1ef023d84da5207c5ae6d8d7465283268e0876f3ef0976d740677349f992a4d57220a32fa191e30d8f433f4cd5d7b888f39a3dd2f4455cd71c47",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/23"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
+        "sha512": "a1dc55b07024658620951df468f6116389d41899e8276cb5c30d870ef6402e8d010c44eff6459b8b5e89e76787b3e3d644d985e2e6fa9d9a9f54e79eb0ebe7b6",
+        "dest-filename": "55b07024658620951df468f6116389d41899e8276cb5c30d870ef6402e8d010c44eff6459b8b5e89e76787b3e3d644d985e2e6fa9d9a9f54e79eb0ebe7b6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/dc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+        "sha512": "9a99729caa9cd42da14d56317743d4db1400736d93235bd284060692c0827f16e7fdd1709c74cd8b56ef62c05392175436d1887f9c4d3a0f77f2bad2498bd2f4",
+        "dest-filename": "729caa9cd42da14d56317743d4db1400736d93235bd284060692c0827f16e7fdd1709c74cd8b56ef62c05392175436d1887f9c4d3a0f77f2bad2498bd2f4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/99"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+        "sha512": "ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+        "dest-filename": "2cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/59"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+        "sha512": "6d7138711fe455984a657fd18cf11f94768a56151597ce67a14defe9bf1aa5f404735c7803ecc1c6367894df0ba8677a599ddd97df29638a3bd7b5459a83e9f8",
+        "dest-filename": "38711fe455984a657fd18cf11f94768a56151597ce67a14defe9bf1aa5f404735c7803ecc1c6367894df0ba8677a599ddd97df29638a3bd7b5459a83e9f8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/71"
     },
     {
         "type": "inline",
-        "contents": "051871dbba4a15121306e3dbd15ae61c5550397d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz\", \"integrity\": \"sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==\", \"time\": 0, \"size\": 4363218, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2e98b46e079a73034fbb58420904a73025ea2b5993a4a0e959fcaa666b1a",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/ad"
+        "contents": "011bc0c125f50644969a5e67247f10620b64509d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vue/-/vue-3.5.25.tgz\", \"integrity\": \"sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==\", \"time\": 0, \"size\": 640733, \"metadata\": {\"url\": \"https://registry.npmjs.org/vue/-/vue-3.5.25.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bfea149d12755cd477375cfe09122ec886974d019052400a0874762a727e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/c0"
     },
     {
         "type": "inline",
-        "contents": "0ba547953d31451fd6be006dd4018376a1ffcc9f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-aO4CYDhFDyNwLnfMi636zbRTyGgPqas9wsBydhnMYABXHuM3OZpE5rFPDdI5PCc2fn4gpajD/FTKHvkMvb0f1w==\", \"time\": 0, \"size\": 37729, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/runtime-vapor/-/runtime-vapor-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ebc9221758808ad9f73503cf7954a7a5915e6dd95c31d976e20d5ad2444b",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/65"
+        "contents": "011cab5dfb852d550380ea6bb5fa8db5479774c8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/markdown/-/markdown-7.5.1.tgz\", \"integrity\": \"sha512-R8uZemG9dKTbru/DQRPblbJyXpObwKzo8rv1KYGGuPUPtjM4LXBYM9q5CIZAComzZupws3tWbDwam5AFpPLyJQ==\", \"time\": 0, \"size\": 35994, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/markdown/-/markdown-7.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "32750012cb2af19f41b043c2c47900d49b4f124567a8d654750887db240a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/00"
     },
     {
         "type": "inline",
-        "contents": "0d8e4da582e97fe90987c9b524e617166cadb1b5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.0.tgz\", \"integrity\": \"sha512-qD5tMjh7utwBk9/5PrTA/aGr3i5QaJ/Mlt7p8NilQ45WgbifUNPyKWsA63iQ8YfQq6R8ajMapU+/Q8nMcPRLNw==\", \"time\": 0, \"size\": 133366, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "926d90d56c3131e120200dab6f1ce426e047c09f1d02b7b68aa6959922c1",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/4f"
+        "contents": "016523998c60ff736093dd7a0526402a673f73fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz\", \"integrity\": \"sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==\", \"time\": 0, \"size\": 11940, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b5e9ca2e40744e7fa089861626d2a29c62363c01729964f4cf0c3e8ee632",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/80"
     },
     {
         "type": "inline",
-        "contents": "15702f0631d7186b95d1e4d1d62a25c16dc94aa0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz\", \"integrity\": \"sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==\", \"time\": 0, \"size\": 4619050, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0246ecbbaa7f0ed8865e1689567e43e2f7c8c3bd0401b0e7682d99d14ad6",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/7f"
+        "contents": "020a05e48a207eea0396419c841d584eabd93ac3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz\", \"integrity\": \"sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==\", \"time\": 0, \"size\": 4529, \"metadata\": {\"url\": \"https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "48127c3d73e2a049f7f3de0e9563028629d39920d88d6e1e20f640a51583",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/54"
     },
     {
         "type": "inline",
-        "contents": "15a56115f737058eccd70c8512dab3bf294c8733\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz\", \"integrity\": \"sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==\", \"time\": 0, \"size\": 4401974, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "dd1373fe27009fca9820b9807a0c31b11458f910360f8db4f9dc74a93472",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/36"
+        "contents": "02a22ee5d2fa58b9c4c230d636d4d55fde6b3038\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz\", \"integrity\": \"sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==\", \"time\": 0, \"size\": 2113, \"metadata\": {\"url\": \"https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5c114d29aba06417ada68b99f5e20e2d4d0cd940f05b138780f7c37e75cc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/7c"
+    },
+    {
+        "type": "inline",
+        "contents": "02fd01ad9a9c24ab35d4348562b21e2c7e9679f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz\", \"integrity\": \"sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==\", \"time\": 0, \"size\": 68410, \"metadata\": {\"url\": \"https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "eeebe1d9d1aeb0be4ce915f9dcb68d5b9c9b4483630ba767e4ca3017514c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/e8"
+    },
+    {
+        "type": "inline",
+        "contents": "036ff542ebb13d8d85f83b27d08b1deb12d7aa92\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz\", \"integrity\": \"sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==\", \"time\": 0, \"size\": 202371, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1ab77d088759d13cd44eab2a2f7764233b7908340d97282d9765e014f29c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/3d"
+    },
+    {
+        "type": "inline",
+        "contents": "0427d060610e6407172222f72457175387df3dc7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz\", \"integrity\": \"sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==\", \"time\": 0, \"size\": 8749, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "10e0310d8dc55382d98d53954a78a27fea14e9953d2586be0a44505768b1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/a1"
+    },
+    {
+        "type": "inline",
+        "contents": "046742ddcf7a9dd650a67a25492f7b42043fec75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz\", \"integrity\": \"sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==\", \"time\": 0, \"size\": 2017, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ca47ff09ac9d048c991a5d94c9ef412ffa5496c2ab672947137bfb61e829",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/69"
+    },
+    {
+        "type": "inline",
+        "contents": "04d4fe9336273610d75ba840d667ff9cc8c75ee3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz\", \"integrity\": \"sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==\", \"time\": 0, \"size\": 2433, \"metadata\": {\"url\": \"https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "199329b02915572faa5ff439b52c860d19665f3c62c1faac64ab534f02db",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/26"
+    },
+    {
+        "type": "inline",
+        "contents": "062c157a258c356eb5d0ff406805815d4fbd2c7b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz\", \"integrity\": \"sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==\", \"time\": 0, \"size\": 8996, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "453bd89145eccf9d67f5797fb09e5a017b5b13f1ac45cb7b70bda45940ec",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/e7"
+    },
+    {
+        "type": "inline",
+        "contents": "065e6f735b7962c096e9bd14d4f778ad1ff80979\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==\", \"time\": 0, \"size\": 5958, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a7a6ecc7be2743dbf1f123c79fbcc029707f54eb12e6ca4afd5579033b7c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/95"
+    },
+    {
+        "type": "inline",
+        "contents": "06a8b4f3802d2b1bb686559c269d832a4aa0710e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz\", \"integrity\": \"sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==\", \"time\": 0, \"size\": 16903, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "384ffde9ef8392c69477a1ebf6682efd61f66830b337702a98afb495b5b4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/ad"
+    },
+    {
+        "type": "inline",
+        "contents": "08cd239c7edcaec92c37ce0ff7452f7d05d1fd8f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz\", \"integrity\": \"sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==\", \"time\": 0, \"size\": 3862, \"metadata\": {\"url\": \"https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ef3387883a75b9b2c4c5f717f74c3445b0234708cc82845d54a4470cdd48",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/13"
+    },
+    {
+        "type": "inline",
+        "contents": "0a0a0339ad01b8e489dfe092745bed0e2c6d8629\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz\", \"integrity\": \"sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==\", \"time\": 0, \"size\": 5904, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "72d3e78c2c11e09d3d49c4f5549b0d45b74c0445e5f6e381247d38cfee2f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/9d"
+    },
+    {
+        "type": "inline",
+        "contents": "0b59916637bf7c6a01915553a6d560b690af48cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz\", \"integrity\": \"sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==\", \"time\": 0, \"size\": 4031875, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0eef90b20ad3b7ff170ff6dd67be843b800378aa0e48070b1f44b6be2093",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/83/37"
+    },
+    {
+        "type": "inline",
+        "contents": "0b7b2dc8fb1e72638fff7638e0879ad78429f9fa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz\", \"integrity\": \"sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==\", \"time\": 0, \"size\": 5928, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "419224f61b4dee999548d94866a6d4732a1305a497db0e78f5af71aad359",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "0ba07c76edb7b0549e4eb18d5d7535719e334f72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz\", \"integrity\": \"sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==\", \"time\": 0, \"size\": 11386, \"metadata\": {\"url\": \"https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "983715e08558f1b2cfbc30f8f65cc1e37b7aa55cfc8580138feb31094765",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/07/67"
+    },
+    {
+        "type": "inline",
+        "contents": "0bd8d5456a061a134a29c87f0e5904c9f3776848\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz\", \"integrity\": \"sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==\", \"time\": 0, \"size\": 4390982, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4624f6a9ec615050f4e610f67b1d1969af7af266a5a35813e63bcbc42381",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/e1"
+    },
+    {
+        "type": "inline",
+        "contents": "0d1497151c44af17d6b6c61c83d1854b64400e93\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.5.4.tgz\", \"integrity\": \"sha512-usuVvl6zdqIkUgQlodxvvFBR7HIZIjWQqQemnc7ysqEP4jubLsDaaOhiJAwVz8PlrkBJRuHkC6PCux+OcEF6hg==\", \"time\": 0, \"size\": 97007, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.5.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fa918766fb8af8d8c52c9f4443d4ae53d4b3ad20ddf201ac2df113ea1583",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b2/65"
+    },
+    {
+        "type": "inline",
+        "contents": "0d6e9f7872c85b3808eb5113a61afdc2fb748cef\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-BUjAEgpABEJXilGq/BPh7jeU3WAJ5o15c1ZEgHaDWSz3LB881LQZnbNJHmUiM4d1JQWMYYyR1Y490IBHi2FPJg==\", \"time\": 0, \"size\": 3555646, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fd7036579ee15f770d677be70b0e9d1381fe817b47edd8bcfc6d36255350",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/ca"
+    },
+    {
+        "type": "inline",
+        "contents": "0dc924b64af87ab39aeff16a4457224840b056cd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz\", \"integrity\": \"sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==\", \"time\": 0, \"size\": 12933, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "10d8b04adc3dc5b782da868234e16e414836ffe607615de8d2f5370edf56",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/e4"
+    },
+    {
+        "type": "inline",
+        "contents": "0e3e7de49f8224bc3d9d3441a579442a026befe7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz\", \"integrity\": \"sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==\", \"time\": 0, \"size\": 4692, \"metadata\": {\"url\": \"https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "23ca797d07c705fb9397b48684b4cea090967e9e5e8469d64306fbe66d73",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d3/a3"
+    },
+    {
+        "type": "inline",
+        "contents": "0e988046d56898e70ab1114fc684920b0290e98b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz\", \"integrity\": \"sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==\", \"time\": 0, \"size\": 4026, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bfec303869cdeaf826bb1082646858b3a183e9178691ae2821a6f4a0baba",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/23"
+    },
+    {
+        "type": "inline",
+        "contents": "10383cbc406ce667dfdb3ec20c9cb4735c17f560\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz\", \"integrity\": \"sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==\", \"time\": 0, \"size\": 49182, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "41cddf7c60568acfeed0869cdf9f384405d790e2b8171deb9b6ea9234cab",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/ec"
+    },
+    {
+        "type": "inline",
+        "contents": "1259b17ba2d77373583b278983f07ecddf338d8f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.8.tgz\", \"integrity\": \"sha512-deKgwx6exIHeZwF601P1ktZKNF0bepaSN4jBU3AsbldPx9gylUc1JDxYppl82yxgkAgaz0Y0LCLOi+cXe9HMYA==\", \"time\": 0, \"size\": 2146, \"metadata\": {\"url\": \"https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0d1f192c44a6d03cd6c14dfb6670fb2067dc72514e2c0209be7057ad538e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/e4"
+    },
+    {
+        "type": "inline",
+        "contents": "138556ce598363b08e4ff3ec384273830ec30118\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz\", \"integrity\": \"sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==\", \"time\": 0, \"size\": 3640280, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ddcd64885edcf149f13599574a68499d5044821ae10b82d9b171eee97e3e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/34"
+    },
+    {
+        "type": "inline",
+        "contents": "1399cbea7cbee96ca6e336db354601859c14ebc6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz\", \"integrity\": \"sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==\", \"time\": 0, \"size\": 17273, \"metadata\": {\"url\": \"https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fbb20dd7b54a8a059e8b5fb24f6a9bab83cf36e50b4b3961fcb6e82a9ae9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/a6"
+    },
+    {
+        "type": "inline",
+        "contents": "14dfbf00b8e71f7fd7a2e184c79f5afaf51e3a62\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz\", \"integrity\": \"sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==\", \"time\": 0, \"size\": 17351, \"metadata\": {\"url\": \"https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "335079766b8aaf8bdf90fad95c09f6b1a460ce01d6d5e5dff777b2b7518e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/b5"
+    },
+    {
+        "type": "inline",
+        "contents": "154789cb0ec59b7b4e1471f657ee56bb0b7a9b59\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globals/-/globals-16.5.0.tgz\", \"integrity\": \"sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==\", \"time\": 0, \"size\": 27062, \"metadata\": {\"url\": \"https://registry.npmjs.org/globals/-/globals-16.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e7cfbe1847377360185bf4f92c7f00c088652d9ca2bbd2ca9fb46a1bba41",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c0/57"
+    },
+    {
+        "type": "inline",
+        "contents": "1592353cc7466b045301c4fed30c9d8f3dcdb116\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.78.0.tgz\", \"integrity\": \"sha512-rQkU5u8hNAq2NVRzHnIUUvR6arbO0b6AOlvpTNS48CkiKSn/xtNfOzBK23JE4SiW89DgvU7GtxLVgV4Vn2HBAw==\", \"time\": 0, \"size\": 34342, \"metadata\": {\"url\": \"https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.78.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e4e0687b798e5ef646df59a1007fad304c1ea3a17eb48b5bc18a385ceffc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e5/7b"
+    },
+    {
+        "type": "inline",
+        "contents": "15f2a26dee6232923f503ae9908c51f6b95100df\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz\", \"integrity\": \"sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==\", \"time\": 0, \"size\": 69487, \"metadata\": {\"url\": \"https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aef3000a5e3b68d26b745ba08bef8b983761fbd810bd7cbec769edf214d3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/29"
+    },
+    {
+        "type": "inline",
+        "contents": "16cda825fa047b82a25a66f2bad43bade6f8084f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz\", \"integrity\": \"sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==\", \"time\": 0, \"size\": 51250, \"metadata\": {\"url\": \"https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "69a271844918a9ef7ae436a685237064d954dbd66b89b7cd7ad4804003d9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/dd"
+    },
+    {
+        "type": "inline",
+        "contents": "16d1738626d9bbb74c39fdddfee482c1e4ebd90c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz\", \"integrity\": \"sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==\", \"time\": 0, \"size\": 638356, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "17129a9b96c7dca0f1b776d38aa74a60e3369e7e229d1db88cb39d476d5c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/75"
+    },
+    {
+        "type": "inline",
+        "contents": "16f9faa5644946ab30579fa0b55f2da75f8d6bf7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz\", \"integrity\": \"sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==\", \"time\": 0, \"size\": 4608175, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5d77ab380ed328843ee56ab41fa463040666a1c6c85d8bf2b78fbc21512d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c0/79"
     },
     {
         "type": "inline",
@@ -875,15 +2980,87 @@
     },
     {
         "type": "inline",
-        "contents": "1a4fd660d56c7e4e9162e462627181bf0f9d9aa3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz\", \"integrity\": \"sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==\", \"time\": 0, \"size\": 4705045, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "335cf3118a630d79f4f8ff2c0df4dbf006f7c7de3837880196e0950c45de",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/2c"
+        "contents": "180bbad1165e58ff8b72963f491a1cff2f68bdd7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz\", \"integrity\": \"sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==\", \"time\": 0, \"size\": 74352, \"metadata\": {\"url\": \"https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9e9b5d50cf2fef0ab95ec9dd29de3dd4c03bc754f9f2d5136150adbf3fd1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/55/46"
     },
     {
         "type": "inline",
-        "contents": "1b33b087b76badbda4d785adf27e8bc8f1535469\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.99.0.tgz\", \"integrity\": \"sha512-8iE5/4OK0SLHqWzRxSvI1gjFPmIH6718s8iwkuco95rBZsCZIHq+5wy4lYsASxnH+8FOhbGndiUrcwsVG5i2zw==\", \"time\": 0, \"size\": 35013, \"metadata\": {\"url\": \"https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.99.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8623ce37477f3ca16b4b9992ab24b1824ce715781163b3099f6493041f30",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/00"
+        "contents": "193aa3b4f57bbbe4315d1b86ea91c2b9f4d1bd80\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz\", \"integrity\": \"sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==\", \"time\": 0, \"size\": 7317, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fdb2d42f6c3c21defd0a1b565d934a989433acc5b1d61cdce086b6bf2db3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2b/9c"
+    },
+    {
+        "type": "inline",
+        "contents": "1989a2e7f58f6b7233ccc01fe2f9451b219c8f4b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz\", \"integrity\": \"sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==\", \"time\": 0, \"size\": 111608, \"metadata\": {\"url\": \"https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "752524d30af777e4e88b58fc44d19c1a8196adf12769f296fb5158c46789",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/4c"
+    },
+    {
+        "type": "inline",
+        "contents": "1998bea7fbc21672e7e9c2f0c8e58565c028809f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz\", \"integrity\": \"sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==\", \"time\": 0, \"size\": 4207887, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5ff75784bcd82e786cbbbb07c4173f34acb51f0b571af0b23a3e182327b0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/55/3d"
+    },
+    {
+        "type": "inline",
+        "contents": "1ac43834be75336b1b391deb7fa623cdeb8a45ba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz\", \"integrity\": \"sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==\", \"time\": 0, \"size\": 3487, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b457937e3a5ae575cbe91d7530c3a2ddbee04dbdbd3bb17c77e9fc51fb76",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/13/e2"
+    },
+    {
+        "type": "inline",
+        "contents": "1ac7c5cc22be1041a0a1e1f5c570b985af2dc141\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz\", \"integrity\": \"sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==\", \"time\": 0, \"size\": 14210, \"metadata\": {\"url\": \"https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6daf1aca65423212b254c589757b1de8a5d377cdc0c6e547e022cbe14588",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/80"
+    },
+    {
+        "type": "inline",
+        "contents": "1ad5e60331f6634b7da563e23a5182bdd0f46183\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz\", \"integrity\": \"sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==\", \"time\": 0, \"size\": 3656, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aefda99ca03a1004596e312ea5d597c682502fb85fe4283d6c1079cacd8f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/f8"
+    },
+    {
+        "type": "inline",
+        "contents": "1aea9fed60630ba70ff870ee7a68ae7c6d6e2169\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz\", \"integrity\": \"sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==\", \"time\": 0, \"size\": 4403982, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1b6e23cc7b15e6201af01ee62ed4859d0371c7ce76f8fc7a400412c6006a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ef/52"
+    },
+    {
+        "type": "inline",
+        "contents": "1b95448fcd986815b5bfdc8ec4679e90f77c1de6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz\", \"integrity\": \"sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==\", \"time\": 0, \"size\": 9434, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8bffe4362381c865b10d98bb4e2143070ad5937e954ef39326f93f83cea3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/2a"
+    },
+    {
+        "type": "inline",
+        "contents": "1bb23437abc42112dfed4b487e771389217e5878\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.0.0.tgz\", \"integrity\": \"sha512-c7YbokssPOSHmqTbSAmTtnVgAVa/7lumWNYqomgd5KOMyPrRve2anx6lonfOsXEQacqF9FKVUj7bLg4vRSvdYA==\", \"time\": 0, \"size\": 195449, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f6e0d3f8d439dc68a903167a1c9823b4f57c369b66e1de434942d71d3ee2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b1/c0"
+    },
+    {
+        "type": "inline",
+        "contents": "1bc55635c10f8dcceb26d9b0e2c526790fe9328f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz\", \"integrity\": \"sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==\", \"time\": 0, \"size\": 130851, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "20caa7361dceb89faadc7a9156eebf36d46ab0c90f7f14784f17890601af",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/b2"
+    },
+    {
+        "type": "inline",
+        "contents": "1bca3c8127376e6d1e8ae0a0d2eeb5c57ce7a4a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz\", \"integrity\": \"sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==\", \"time\": 0, \"size\": 6036, \"metadata\": {\"url\": \"https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f5389397ecaf3f3c215bf69f144a97876c046ced1baca2cab47d3deed418",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/29"
+    },
+    {
+        "type": "inline",
+        "contents": "1ca09ff01bdbe638f3b844d3aa65eb4607aa7a43\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz\", \"integrity\": \"sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==\", \"time\": 0, \"size\": 5740, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "76e3798cbc13f0e3378766ce5c005e62a623f55505330c8ab25b07ba3ca4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/12"
+    },
+    {
+        "type": "inline",
+        "contents": "1cf3e5090e2ab46d6597f842b53a7945b0e46862\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/refa/-/refa-0.12.1.tgz\", \"integrity\": \"sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==\", \"time\": 0, \"size\": 230951, \"metadata\": {\"url\": \"https://registry.npmjs.org/refa/-/refa-0.12.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "12e6aa5a7985e86a1dac26b6493562fbbbec5e2ba92ea02df4115c30d98f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/d4"
     },
     {
         "type": "inline",
@@ -893,9 +3070,45 @@
     },
     {
         "type": "inline",
+        "contents": "1dfebdf2881316f6c6d801a957dbb1fd42f3153d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz\", \"integrity\": \"sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==\", \"time\": 0, \"size\": 4372, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "587c4c38d087f1c45e5dee0a05e7378358d3f028c32fb5ab3d1d957bdd33",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/de"
+    },
+    {
+        "type": "inline",
+        "contents": "1e3f47a9ea75e112483181a53b112f35f9078df9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz\", \"integrity\": \"sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==\", \"time\": 0, \"size\": 10964, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6cd5987464e1e13f7c41e83e8452879d3c8faa2b56d7fb9adf3c6a9d302e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/31"
+    },
+    {
+        "type": "inline",
+        "contents": "1eb28844ec51387ac177e1626063d04081686751\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz\", \"integrity\": \"sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==\", \"time\": 0, \"size\": 25248, \"metadata\": {\"url\": \"https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fde15b74bdf85a34a99dc45064eadfa744780b239c71f7fc82d572c68c6b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/47"
+    },
+    {
+        "type": "inline",
+        "contents": "1ec7e2b0b0732c43a6564e7cb00f1fd85fc64c58\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz\", \"integrity\": \"sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==\", \"time\": 0, \"size\": 4245147, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "284d3577c649673281df4dec4ba8db74403725b630d7f4659d70921db4cd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/3f"
+    },
+    {
+        "type": "inline",
         "contents": "1f1360e5d553e43987a0ca841e78b1590135a7fa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz\", \"integrity\": \"sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==\", \"time\": 0, \"size\": 7359, \"metadata\": {\"url\": \"https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "6cdae5ff3c31cdc1601fd4bae0943ca1fe8ba2d67c65455e7b0269b4df11",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/af"
+    },
+    {
+        "type": "inline",
+        "contents": "1f93a67db8cdc48e00098f4092350c43034b1e7c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz\", \"integrity\": \"sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==\", \"time\": 0, \"size\": 43125, \"metadata\": {\"url\": \"https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f0a803b0e4462c28e95014cdede50ae46a13d2cb8144f88aa2810ef10dfc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/c6"
+    },
+    {
+        "type": "inline",
+        "contents": "205ef262e8fcf726f69586b836cbb594fc929f4a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz\", \"integrity\": \"sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==\", \"time\": 0, \"size\": 6600, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f91dc003bac9019c1d6c60e8f388a714c6ddece16ab17500b2b2b242f499",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/9d"
     },
     {
         "type": "inline",
@@ -911,9 +3124,57 @@
     },
     {
         "type": "inline",
-        "contents": "222d84d5036b82ae8342af74f1a16a2d38ab3d46\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-klahlb2EIFltSUubn/VLjuc3qxp1E7th8ukayPfdkcKvvYcQ5rJztgx8JsJSuAKVzKtNTqUGOhy4On71BuyV8g==\", \"time\": 0, \"size\": 8533932, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1b46f3754e4df51b5b547fcf893e4487f79b39ae4ae1f93d52606066427d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/30"
+        "contents": "226fd396eb475e65e18397cafc5d1830a2b37cbd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz\", \"integrity\": \"sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==\", \"time\": 0, \"size\": 11701, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a90638ddda5d2b9ae34081f69699c684c69984cdb87ba26e6dc3c305c202",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/c6"
+    },
+    {
+        "type": "inline",
+        "contents": "22a56a4cd0414d0b3690becdec4e1ebf13f0e0dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz\", \"integrity\": \"sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==\", \"time\": 0, \"size\": 1951, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6149661c453e9896445eb249a914c680462121e4f460635ec401d9394202",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/73"
+    },
+    {
+        "type": "inline",
+        "contents": "22e3eeb23de6cf75eed950e409abbcf6a63ec853\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz\", \"integrity\": \"sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==\", \"time\": 0, \"size\": 2493, \"metadata\": {\"url\": \"https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ef3d4ad39921735a14450622be6e29f3834b75fb5b70e5a88f143cda507a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/f2"
+    },
+    {
+        "type": "inline",
+        "contents": "23ea355e85dd683cfe9c3291274d34660e3a9e74\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz\", \"integrity\": \"sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==\", \"time\": 0, \"size\": 3898, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5cef805eb593de4e7b0efe752cf10cb2e68e9688253516ba5ecd16ef4c9f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/9d"
+    },
+    {
+        "type": "inline",
+        "contents": "24082ab230905c3d4fb86468328b67dcad55f820\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/espree/-/espree-9.6.1.tgz\", \"integrity\": \"sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==\", \"time\": 0, \"size\": 16332, \"metadata\": {\"url\": \"https://registry.npmjs.org/espree/-/espree-9.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3d0b601ff8f03972fae59d99197a79a33075e08fe5f8cc5469c49c4adb35",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/46"
+    },
+    {
+        "type": "inline",
+        "contents": "243362e7dffaadbb60c05979260fb5514ddb75b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz\", \"integrity\": \"sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==\", \"time\": 0, \"size\": 458057, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3618477794028d2146505db82a7dd0c29ea67fd7bf6331cd5a56ec19074c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/d2"
+    },
+    {
+        "type": "inline",
+        "contents": "244036e4362860dbf936e83073280bef4a5e4045\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz\", \"integrity\": \"sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==\", \"time\": 0, \"size\": 4312, \"metadata\": {\"url\": \"https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e444d001268ef2d4c2a6c96efcf4cbe9d51fdc9008329f7956b60986aef9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/28"
+    },
+    {
+        "type": "inline",
+        "contents": "244b62b37a7679ea682248e63d5367ecfb7d4d73\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-cjWL/USPJ1g0en2htb4ssMjIycc36RvdQAx1WlXnS6DpULswiUTVXPDesTifSKYSyvx24E0YqQkEm0K/M2Z/AA==\", \"time\": 0, \"size\": 8682708, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bc2d5009f2b8711437fed03d5a2743fdb0ab3c0a241a300c6ba011fa488f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/a4"
+    },
+    {
+        "type": "inline",
+        "contents": "2592bcaa961b17a51a7b5d947d0d1f0f1be43122\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz\", \"integrity\": \"sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==\", \"time\": 0, \"size\": 6714, \"metadata\": {\"url\": \"https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7685e53aaa1f726b0a7cdd6b569941e37da8cabfc9f4168b3c0f1a97e92b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/4d"
     },
     {
         "type": "inline",
@@ -923,9 +3184,75 @@
     },
     {
         "type": "inline",
-        "contents": "27187bd009be7c11ec77d0acffa361d1f3a84b3e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.23.tgz\", \"integrity\": \"sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==\", \"time\": 0, \"size\": 42069, \"metadata\": {\"url\": \"https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.23.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3355d24362a8d78104b5f12b0833852b02da397c76b836a17cb9b701e4fc",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/3e"
+        "contents": "26f36a21509b9b94657a7afcc3bf714a87fc4a74\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-GTXe+mxsCGUnJOFMhfGWmefP7Q9TpYUseHvhAhr21nCTgdS8jPsvirb0tJwM3lN0/u/cg7bpFNa16fQrjKrCjQ==\", \"time\": 0, \"size\": 8248894, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "86abd7ae6b4b7a849c15973097e71c3b5cbbea38bc7ee620431a26fb3ee6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/41"
+    },
+    {
+        "type": "inline",
+        "contents": "27f17e31253ac77ad0325bb2759fec1226965667\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz\", \"integrity\": \"sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==\", \"time\": 0, \"size\": 591385, \"metadata\": {\"url\": \"https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8218f1c78820a6478dad5e33e3f65501f2a3221f8da812e9fff25220915a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cc/d0"
+    },
+    {
+        "type": "inline",
+        "contents": "284c84324290bb0381b0492a8e4d5940bb06f956\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.26.tgz\", \"integrity\": \"sha512-N87ecLD48Sp6zV9zID/5yuS1+5foj0DfuYGdQ6KHj/IbKvyKv1zNX6VCmnKYwtmHadEO6mFc2EKISiu3RDPAvA==\", \"time\": 0, \"size\": 42644, \"metadata\": {\"url\": \"https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.26.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0f4a068f742d9c52b67c07260f6495dc5d2026860c8fe903916af62948da",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ad/d0"
+    },
+    {
+        "type": "inline",
+        "contents": "28985d61bd4a882a1a7861c931e0fffbda065b6c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz\", \"integrity\": \"sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==\", \"time\": 0, \"size\": 6779, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fefef5c06cc570a726f66b226d6abde231b9f5de2ae35354240c598b5518",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/17"
+    },
+    {
+        "type": "inline",
+        "contents": "29157ba4a62a698640fb88bc4cd86cc285e8af50\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz\", \"integrity\": \"sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==\", \"time\": 0, \"size\": 46459, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "438b351151e94a7f263238944acf9eff91a0b629a374574c94bfae84d934",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/8e"
+    },
+    {
+        "type": "inline",
+        "contents": "295b3a382b7c7583fc2aaacfae8ef5f34b588e0e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz\", \"integrity\": \"sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==\", \"time\": 0, \"size\": 3640277, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "abb459952f55584e04f1058d120392c353f34c0fa4c05f39089c883a5a44",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1d/35"
+    },
+    {
+        "type": "inline",
+        "contents": "29e29b09157a8c637b2477ff210310d097f1c488\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz\", \"integrity\": \"sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==\", \"time\": 0, \"size\": 5681, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a60d06e8c93e5ba41fedcf563ff838a3483e19fe65edb616a8b86fe0ac3a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/cb"
+    },
+    {
+        "type": "inline",
+        "contents": "2ac9a79d1b3a654c01c79e82369b2bb23d6a8595\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-command/-/eslint-plugin-command-3.4.0.tgz\", \"integrity\": \"sha512-EW4eg/a7TKEhG0s5IEti72kh3YOTlnhfFNuctq5WnB1fst37/IHTd5OkD+vnlRf3opTvUcSRihAateP6bT5ZcA==\", \"time\": 0, \"size\": 17500, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-command/-/eslint-plugin-command-3.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7d2fb1622afb0ad615a2ce0a8eb30f9c53ea6cb3932fc438740f25a9a84b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/c1"
+    },
+    {
+        "type": "inline",
+        "contents": "2c80e9c68255018f86bc2e4ee2c6ce69fe996c70\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz\", \"integrity\": \"sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==\", \"time\": 0, \"size\": 2600, \"metadata\": {\"url\": \"https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ed8b1c3259b5490cf1d267d292f77895573e71628ad34e51e699096d46e1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/af"
+    },
+    {
+        "type": "inline",
+        "contents": "2d656f4a4ba9d0302a365f8255219f5edc7fbd10\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz\", \"integrity\": \"sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==\", \"time\": 0, \"size\": 11398, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e236d9a349e738c8841f9d14a32f0d4d269da22830565d660e941dc2ff4e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/45"
+    },
+    {
+        "type": "inline",
+        "contents": "2da96e9e1880864ebba12c4302c06d5e62344033\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-Ok9V8o7o6YfSdTTYA/uHH30r3YtOxLD6G3wih/U9DO0ucBBFq8WPt/DslU53OgfteLRHITZny9N/qCUxMf9kjQ==\", \"time\": 0, \"size\": 8069586, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d514f5b44bef5db78d654a81ed777332d9016c9d1a93903b5bc43e8ff3e2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/9f"
+    },
+    {
+        "type": "inline",
+        "contents": "2eca20e0748d5dcf252188fd179a5da11e75e914\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz\", \"integrity\": \"sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==\", \"time\": 0, \"size\": 4234, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bae44c978d78f4471b8b2a580f3c644fa83d9c9dbb3215d8b731ccab8940",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/a3"
     },
     {
         "type": "inline",
@@ -935,15 +3262,27 @@
     },
     {
         "type": "inline",
-        "contents": "2f56b5997f5bfe62d5c57aa7e5e0830a1387ac1d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-a4EkXBtnYYsKipjS7QOhEBM4bU5IlR9N1hU+JcVEVeuTiaslIyhWVKsvf7K2YkQHyVAJ+7/A9BtrGqORFcTgng==\", \"time\": 0, \"size\": 8178086, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "6ad50cd371c6e67167880bfbd35e765149902646fb55055cd8ecb161fef9",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/40"
+        "contents": "2fa0b0bc19ef8fece15203237809798aed4ae923\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-merge-processors/-/eslint-merge-processors-2.0.0.tgz\", \"integrity\": \"sha512-sUuhSf3IrJdGooquEUB5TNpGNpBoQccbnaLHsb1XkBLUPPqCNivCpY05ZcpCOiV9uHwO2yxXEWVczVclzMxYlA==\", \"time\": 0, \"size\": 2935, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-merge-processors/-/eslint-merge-processors-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "41214bad8e6435a31e43567576adef81d1fc42e813f542a3282bf71dfd39",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/57"
     },
     {
         "type": "inline",
-        "contents": "35d771e78396d56ecdf14cccde02d5aa2d73e30b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-MBGIgysimZPqTDcLXI+i9VveijkP5C3EAncEogXhqfax6YXj1Tr2LY3DVuEOMIjWfMPMhtQSPup4fSTAmgjqIw==\", \"time\": 0, \"size\": 8059395, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "87d37527c032ef1396522f056d057f496cf1740d41d0328f89c4b394ba10",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/40"
+        "contents": "30bfbaab420e817dcb1676780c7647408b0a126b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz\", \"integrity\": \"sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==\", \"time\": 0, \"size\": 6310, \"metadata\": {\"url\": \"https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "da9219e0fff322eda98e08eba4e2bc8f8e49ef16ee3164af8ba48b1c2045",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/20"
+    },
+    {
+        "type": "inline",
+        "contents": "32414013c606f88374a976968c132aabdf90af6c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz\", \"integrity\": \"sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==\", \"time\": 0, \"size\": 185236, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f98963c94ff10472884acf39e67c0ac400e249f097a7dc36e79c41f395ea",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/a1"
+    },
+    {
+        "type": "inline",
+        "contents": "335eb52e2a5088c515cecdc6526466fecb689e66\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.101.0.tgz\", \"integrity\": \"sha512-t3qpfVZIqSiLQ5Kqt/MC4Ge/WCOGrrcagAdzTcDaggupjiGxUx4nJF2v6wUCXWSzWHn5Ns7XLv13fCJEwCOERQ==\", \"time\": 0, \"size\": 35014, \"metadata\": {\"url\": \"https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.101.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "92bd1c1797890645780062cc2c8d1914702e1288b11e1820e9c44d739ff5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ef/12"
     },
     {
         "type": "inline",
@@ -953,21 +3292,39 @@
     },
     {
         "type": "inline",
-        "contents": "360dff1003c6b4b6f34d34039698538631783c27\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz\", \"integrity\": \"sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==\", \"time\": 0, \"size\": 30946, \"metadata\": {\"url\": \"https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a8b462f2e3191aed5061958a700d17877ec744aee1efcb0353a059401b81",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/f4"
+        "contents": "35fae4406055ce760af4668976cd556b0d2d6e76\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz\", \"integrity\": \"sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==\", \"time\": 0, \"size\": 135881, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e83be37b4c259376075d1ab5fe5333685a099333034fea88ad9e9517989f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b5/27"
     },
     {
         "type": "inline",
-        "contents": "39cfd0646c9a502efe41bc7d9c931fab0a939902\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-5ZXcYyd4GxPA6QfbGrNcQjmjbuLGvfz6728pZMsQvGHI+06LT06M6TPtXvFvLgXtexc+OqvFe1yAIXJU1gob/w==\", \"time\": 0, \"size\": 7868264, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0a3a737114924a3a20ab55650580a329e09713878fb58c379731be44c7fe",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dc/a5"
+        "contents": "3643e05fc0fc528a28215e2a1c0ebfc8b83b102c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz\", \"integrity\": \"sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==\", \"time\": 0, \"size\": 61522, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f4520ff0468eebff952e3bd87c3922487d5ac1aed2ecc5b1973873fee3fc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/76"
     },
     {
         "type": "inline",
-        "contents": "3c383604d3b9b254658d889aa528994b6f502dca\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz\", \"integrity\": \"sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==\", \"time\": 0, \"size\": 4607459, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1aa9abbba716d929a33b15e744c0653092a8570c76106e2c4d44f189a889",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/29"
+        "contents": "368b17009ff730426e092f73f496e18ebf7e2841\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.4.3.tgz\", \"integrity\": \"sha512-Q8B3SWuuISy/Ciag4DFP7MCrJX07wfaekcqD2o/msdIj4x8Ql3bZ/NEKOXV7mTVh7m1YdiFWiMi9xH+0zuEGHw==\", \"time\": 0, \"size\": 3038, \"metadata\": {\"url\": \"https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0f9f5bd1c513fad6e46524f165280107089a51bcf0b9607275226966a59b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/2c"
+    },
+    {
+        "type": "inline",
+        "contents": "38ad9957959970ff4e86a36ce869d2788520840d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz\", \"integrity\": \"sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==\", \"time\": 0, \"size\": 7628, \"metadata\": {\"url\": \"https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cc52fd273313ba7b844c0b41d48967478528bcc0103ff9bb75327f8039c0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/49/4e"
+    },
+    {
+        "type": "inline",
+        "contents": "3a85867cb62b93dbbefea572b2ed784b8071daeb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz\", \"integrity\": \"sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==\", \"time\": 0, \"size\": 3163, \"metadata\": {\"url\": \"https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "afaffbc93c006cd6f3e405f9ea28abeb52cd59df0c10f633f9804fa26db4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/d9"
+    },
+    {
+        "type": "inline",
+        "contents": "3c105848a8eab7d1e5dfc1c6675ac74f5ddfab09\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.15.1.tgz\", \"integrity\": \"sha512-MHF0cBoOG0XyBf7G0EAFCuJJu4I18wy0zAoT1OHfx2o6EOx1EFTIzr2HGeuZa1kDcusoX0xJ9V7oZmaeFd773Q==\", \"time\": 0, \"size\": 54902, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.15.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "de288a0e51ee3fb42dcecff7743109aa83f3a7a6821e34f7fff83ac42e84",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/8e"
     },
     {
         "type": "inline",
@@ -983,9 +3340,39 @@
     },
     {
         "type": "inline",
-        "contents": "3f3fa21175b5b8356c3815d86ad68666ac262408\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.5.tgz\", \"integrity\": \"sha512-L/G9IUjOWhBU0yun89rv8fKqmKC+T0HfhrFjlIml71WpfBv9eb4E9Bev8FMbyueBIU9vxQqbd+oOsVcDa5amGw==\", \"time\": 0, \"size\": 2146, \"metadata\": {\"url\": \"https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f40f68385dc18e46ab6649d66c095b8a0accbe6eda96fdf4e95138792846",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/90"
+        "contents": "3d736da04b29084a5778eedeafef7aad2c195def\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz\", \"integrity\": \"sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==\", \"time\": 0, \"size\": 12586, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "831874b256a097be2bd21b7331e77024f4edf398485fb8ed1b2d3a77b077",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/10"
+    },
+    {
+        "type": "inline",
+        "contents": "3d7868d4bddffd4c62f527ac0472ce5497f15685\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-62.0.0.tgz\", \"integrity\": \"sha512-HIlIkGLkvf29YEiS/ImuDZQbP12gWyx5i3C6XrRxMvVdqMroCI9qoVYCoIl17ChN+U89pn9sVwLxhIWj5nEc7g==\", \"time\": 0, \"size\": 175929, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-62.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ae9f7bf1f7a177d818ce14d8f2a160cd9494237915f25105bfa4d0d2ebf5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/9c"
+    },
+    {
+        "type": "inline",
+        "contents": "414673d2433e91e0bc638cc17ca77f3ffd91751d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz\", \"integrity\": \"sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==\", \"time\": 0, \"size\": 6594, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "03e3f3febea00680991571cfae55efa78672ec69a9c9a2c1b3fa542ab3da",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/8d"
+    },
+    {
+        "type": "inline",
+        "contents": "4231a70fe59e599d1f625830a2d095ac78a97008\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz\", \"integrity\": \"sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==\", \"time\": 0, \"size\": 22897, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f96192c1e5287745c2b42995d408d7a3ab359eeb0db22c81c47c643352c7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "424bafdceb021bbf6c03371960363d551c1a8168\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz\", \"integrity\": \"sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==\", \"time\": 0, \"size\": 6593, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2af10ff50c13c105948195a8b546969cad7829ec603709f7dde789c9b0ae",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/9c"
+    },
+    {
+        "type": "inline",
+        "contents": "43440e09bd79a8cc6f4dfb968dc5fe2d560f15ad\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz\", \"integrity\": \"sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==\", \"time\": 0, \"size\": 5240, \"metadata\": {\"url\": \"https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b179097bf33c30fcd5322583f45c0ffe91cb5b4b04eba298df4fb2468743",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b1/90"
     },
     {
         "type": "inline",
@@ -995,9 +3382,21 @@
     },
     {
         "type": "inline",
-        "contents": "44dd73c379b2cc69d16e130bf97b7d70e8a4c893\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz\", \"integrity\": \"sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==\", \"time\": 0, \"size\": 457830, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "edad7d9945a4cb4c204a584a1c854d894ae5c8f4bd2a77ab7e7c356313d2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/2a"
+        "contents": "44d74efb0204e97cdb810fc7661292d42ec85230\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==\", \"time\": 0, \"size\": 8066594, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "53278956e48bf92851e32362784cc2cef3dbcbb6c752fd8b14fa82ea6391",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/c5"
+    },
+    {
+        "type": "inline",
+        "contents": "44f665dc557ec2b17b95a1e989074931041d9dcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-Qd9c2p0XKZdgT5AYd+KgAMggJ8ZmCs3JnS9PTMWkyUfteKlfmKtxJbWTHkVakxwXs1Ub7jrRYVeFeF7N0sQxyw==\", \"time\": 0, \"size\": 119901, \"metadata\": {\"url\": \"https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b5d730a72c5b1e3f873dcfef6a9f1e6dafcfccb722baf913085dec772b45",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/c3"
+    },
+    {
+        "type": "inline",
+        "contents": "450f804211585a0aed61e68c5ec8b5f97de5767e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.7.3.tgz\", \"integrity\": \"sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==\", \"time\": 0, \"size\": 28442, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.7.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e74ef831fdb5e8ceb0af0226792dabdc4942647803027790ad7011631548",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b1/e5"
     },
     {
         "type": "inline",
@@ -1007,15 +3406,75 @@
     },
     {
         "type": "inline",
-        "contents": "4bc56f7ec9a3f1f940999e36e57e69026b1cf225\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-k31SasR388dp6erQ3G9V4fHM8ewvJScHM+wquNiVNAEaZdvjsfVdae+6Mgcflmv2UoPu3/PWJTaih/wKO/jGEw==\", \"time\": 0, \"size\": 16027, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/shared/-/shared-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "a56f6ab898400d96f1a4505a4f8ad3bfd08e528fbb649d8607913e0c7e78",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/43"
+        "contents": "4763f8768a6a8c8f607f53bdba2a3d9a93a27b84\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz\", \"integrity\": \"sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==\", \"time\": 0, \"size\": 4647367, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6adaa45ce12d736bcc9d151c5656640c6e9aa1706d8c2ff8d57f8923cce2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8a/b6"
     },
     {
         "type": "inline",
-        "contents": "4fb1304be43320ae0e7efe283ac7c925bdaa6be0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz\", \"integrity\": \"sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==\", \"time\": 0, \"size\": 3638270, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "bd093ce6e544e940cf5cd8db4f5b3d238d7da7924cf536632ec98498396d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/9f"
+        "contents": "47e328b45f991d262bfc1476098a4c0144f53274\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.21.0.tgz\", \"integrity\": \"sha512-HttlxdNG5ly3YjP1cFMP62R4qKLxJURfBZo2gnMY+yQojZxkLyOpY1H1KRTKBmvQeSG9pIpSGEhDjE17vvYosg==\", \"time\": 0, \"size\": 51134, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.21.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d505d32075c6381ba4cf02d8a35ac2284534f83843d5d94e41ff35dc9484",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/fa"
+    },
+    {
+        "type": "inline",
+        "contents": "48db278273e29ee71c2dcd20b672b8ca60f51513\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==\", \"time\": 0, \"size\": 8563476, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "afc0f39c56b272d9aa7c680e19edfb3e72ca3c818d6f189fc46cfa8e4461",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/ba"
+    },
+    {
+        "type": "inline",
+        "contents": "4922e74f06ebcee2cfd4a24d9292122e1e642833\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-1.19.1.tgz\", \"integrity\": \"sha512-bYkOxyEiXh9WxUhVYPELdSHxGG5pOjCSeJOVkfdIyj6tuiHDxrES2WAW1dBxn3iaZQey57XflwLtCYRcNPOiOg==\", \"time\": 0, \"size\": 47744, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-1.19.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d0fa917c55ebf61af7c28f9020c53094161832f725225c7e23f48be35609",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/12"
+    },
+    {
+        "type": "inline",
+        "contents": "49cdfad06c9b603d8e800338b110210d2818067b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cac/-/cac-6.7.14.tgz\", \"integrity\": \"sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==\", \"time\": 0, \"size\": 21928, \"metadata\": {\"url\": \"https://registry.npmjs.org/cac/-/cac-6.7.14.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ba715ab03e09151e592cad6fa262d10f5d9bffaeb7406108b3cc42b99417",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/43"
+    },
+    {
+        "type": "inline",
+        "contents": "4a99067dad7a4150858edb6cc86d91790765d6eb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.5.0.tgz\", \"integrity\": \"sha512-MAhuTKlr4y/CE3WYX26raZjy+I/kS2PLKSzvfmDCGrBLTFHOYwqROZdr4XwPgXwX3K9rjzMr4pSmUWGnzsUyMg==\", \"time\": 0, \"size\": 10829, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7c47870a93446fe0244fd8f464c3e4adba513d1cfcdcd64827855114ef87",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d4/15"
+    },
+    {
+        "type": "inline",
+        "contents": "4acb9875ebc56c671c2d12c12823a5852ddc90f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz\", \"integrity\": \"sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==\", \"time\": 0, \"size\": 5141, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "570007f66e0a594c21201eb3e8f15d7a4d92bcb97b59246e5b7194b3b290",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/f3"
+    },
+    {
+        "type": "inline",
+        "contents": "4ae6c80db6dd6316da1a4aafbc05a2474cbc2804\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz\", \"integrity\": \"sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==\", \"time\": 0, \"size\": 3799, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b2f28b50a302526f9c1b58c91f95fda70f51a4fb3dab1a95730788fb932a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/2f"
+    },
+    {
+        "type": "inline",
+        "contents": "4af858e54f176d620493f73fee5ba33974c95a9e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz\", \"integrity\": \"sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==\", \"time\": 0, \"size\": 4053, \"metadata\": {\"url\": \"https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3b5c4878bcc451766f7bcf5df7d2a4999739fcb2e30c1dcf6d759fbf963e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/23"
+    },
+    {
+        "type": "inline",
+        "contents": "4b2ad70e6ec214638bffd8ec183dceaddee08680\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz\", \"integrity\": \"sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==\", \"time\": 0, \"size\": 4580, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4b0c6b33393c5204c8918856d985280869d476e283d6aeb1b1977a348def",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/85"
+    },
+    {
+        "type": "inline",
+        "contents": "4e40e703b6cecd2cafa74bfa6095e001074c9f9b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globals/-/globals-14.0.0.tgz\", \"integrity\": \"sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==\", \"time\": 0, \"size\": 17235, \"metadata\": {\"url\": \"https://registry.npmjs.org/globals/-/globals-14.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aa8a49a64aa50b6965e5452104c55b9f97fec3e5c280a171bbc0021410e3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/3e"
+    },
+    {
+        "type": "inline",
+        "contents": "4f532eeaf4e8a7932a11507ceb3c1677e42f53de\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz\", \"integrity\": \"sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==\", \"time\": 0, \"size\": 15266, \"metadata\": {\"url\": \"https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6fd694af3f2a77a99b7f63d7eeca0a3d895a46536c015370e462365772e9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/85"
     },
     {
         "type": "inline",
@@ -1025,15 +3484,51 @@
     },
     {
         "type": "inline",
+        "contents": "51565ca0c2a30a3c301e974d39807d6c10122d83\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz\", \"integrity\": \"sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==\", \"time\": 0, \"size\": 44535, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "312e7d38dc1a9eba724d43ee37273ad7653412cba08485980047d7b7b085",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/27"
+    },
+    {
+        "type": "inline",
+        "contents": "51b19b70248d565674a59683739d10bb662dc675\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz\", \"integrity\": \"sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==\", \"time\": 0, \"size\": 162341, \"metadata\": {\"url\": \"https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "46aa10b993a127cbbc204dbee6d04cba50cf89ef5548269c22d89e4ec6bd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/43/77"
+    },
+    {
+        "type": "inline",
+        "contents": "5246248f80d0b6872b5f178b39a30c9841140727\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz\", \"integrity\": \"sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==\", \"time\": 0, \"size\": 42713, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0b59f7987e107ad6d3ce554dec701914a505fb747efe19a586c2d9421854",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/cb"
+    },
+    {
+        "type": "inline",
+        "contents": "5253832605f86c6276a5482698eb13dc0d362abf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz\", \"integrity\": \"sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==\", \"time\": 0, \"size\": 10514, \"metadata\": {\"url\": \"https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e5c4efbef199493a640315f44c3af6f46c7ff42af11d71143fe691e625a5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e2/f5"
+    },
+    {
+        "type": "inline",
+        "contents": "5275296959f0beb34d155efbfc74cb60589b7467\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz\", \"integrity\": \"sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==\", \"time\": 0, \"size\": 2073, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "470c9cbb447615faafb6dfdf54632831f7f96c77771ea06a1eeffba41373",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/d3"
+    },
+    {
+        "type": "inline",
         "contents": "52fc088406ea39e04a26d2042fd5d92815b06c86\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz\", \"integrity\": \"sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==\", \"time\": 0, \"size\": 216363, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "2a73d832851c13342a379846b5f0d163a0ca9ac7c1e52b6807a841485da5",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/7f/a8"
     },
     {
         "type": "inline",
-        "contents": "54c928a0d57ae50a76260bf6f71270eac9bf9400\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz\", \"integrity\": \"sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==\", \"time\": 0, \"size\": 4391796, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b6119b3b8a8f049cb05fe0d68fa5bbc3633ad5f2d74c9876bf5ad5a1311d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ff/92"
+        "contents": "5361079f52801229b8bd7881a0c02b9d20311ddf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz\", \"integrity\": \"sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==\", \"time\": 0, \"size\": 64354, \"metadata\": {\"url\": \"https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "08ae8107c84e113551dbf8826edde31bd937c1a992b129064fa2a02ee6d5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/b6"
+    },
+    {
+        "type": "inline",
+        "contents": "54373e15d9e93d922b261a1702c0cfa968ea0f48\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz\", \"integrity\": \"sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==\", \"time\": 0, \"size\": 4163, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "24782f0a8edccacc369764ca9221e6e180aec9bc9162dc060ddbfde89c55",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ff/98"
     },
     {
         "type": "inline",
@@ -1043,21 +3538,27 @@
     },
     {
         "type": "inline",
-        "contents": "550ee98927490d053c06111e5ff3e6004838e1f2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-BseRc+JU9AL4b+vr7gnJiCXe0rvlSrgUMjJH2Gkws9EUujyXDQT6QQWZrrL5VE6fpgZ+wyVOg/Mk8aivBv3Cbg==\", \"time\": 0, \"size\": 322965, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "23c6e9a449e91ccaefe05a7dd97767e7cecc4dae459b5ae405fae330b3cd",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/02"
+        "contents": "571adcaa95c2a1a84d281fbb51a88c0ce074d036\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz\", \"integrity\": \"sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==\", \"time\": 0, \"size\": 9146, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e29fc6e888e285300467cc4224ea6fb974ed531347d52d7eeb3c9632099f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/38"
     },
     {
         "type": "inline",
-        "contents": "55a932654b356ab6012bc16b8a4068c2106788d5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-sOVhkO7D0lb+/TNZvmfvDliXncqDKa3zMDkEK2Fd13J5vqKKuEHSZeYrZYYISv1RIT88pJRF/0A6gInKhrKLqQ==\", \"time\": 0, \"size\": 845079, \"metadata\": {\"url\": \"https://registry.npmjs.org/vue/-/vue-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "356c48aed5e0a99c191e8cea35cff970460ad7c50fcdf87d56646a81d4ce",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/66/e1"
+        "contents": "576f481940f475865219aa6b1580979d27ad4f12\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz\", \"integrity\": \"sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==\", \"time\": 0, \"size\": 3818, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9746a86ac64097b697bee41e567e4c2063abee74b20256bb91d8e59994ef",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/b2"
     },
     {
         "type": "inline",
-        "contents": "5781e0490efece9f60f83af82bb1aeaa9dfab69f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-owQr29tdKkazdPb5aaHWFnbtYsvcyflAssqgde7kP6MlNphsDtdYOdDffN13fy54RvEVh5XYAxsRsHEicVvV9w==\", \"time\": 0, \"size\": 81355, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "48b49754f94b1bf4c5cc9bf50a1365bc60957e51cd9419e7e02b8bb6873a",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/77"
+        "contents": "57db739517593eea357e05426331cbee6a60457e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz\", \"integrity\": \"sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==\", \"time\": 0, \"size\": 2008, \"metadata\": {\"url\": \"https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2cbc18156d0b5bd45d43608718e4abeac731fab0a1e48d628756e2cae0e8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/40"
+    },
+    {
+        "type": "inline",
+        "contents": "5807e2601044561203d76b574bcdb0a1138cf2f9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz\", \"integrity\": \"sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==\", \"time\": 0, \"size\": 20524, \"metadata\": {\"url\": \"https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c25138ef1a6468c1b45641025fb3643ebca17c831b4c2ba8aec96083f067",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/19/7e"
     },
     {
         "type": "inline",
@@ -1067,15 +3568,51 @@
     },
     {
         "type": "inline",
+        "contents": "5a2d43381697f72c0f7d85e1673f837b33499cce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.3.0.tgz\", \"integrity\": \"sha512-ZFBmXMGBYfHttdRtOG9nFFpmUvMtbHSjsKrS20vdWdbfiVYsO3yA2SGYy9i9XmZJDfMGBflZGBCm70SEnFQtOA==\", \"time\": 0, \"size\": 4676, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f2f6bdadc2d9c5ffda52046df686cdb543f95f7b58b0f172fc7f3643b34b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/5d"
+    },
+    {
+        "type": "inline",
+        "contents": "5a65c75b12cfeac2053be4a1fd7ace53c25e3d28\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz\", \"integrity\": \"sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==\", \"time\": 0, \"size\": 6356, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8b72800b7eb469c06cd26809ad57786b538e5decbde2af6747e07bbb20fd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/58"
+    },
+    {
+        "type": "inline",
+        "contents": "5ad1478c49b8ecf0a909c5d677929d36985bc127\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz\", \"integrity\": \"sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==\", \"time\": 0, \"size\": 132003, \"metadata\": {\"url\": \"https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a81ec09ff8849df96b20fa9c869a01023fc35e39a6fe539bee503fd77a00",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/30"
+    },
+    {
+        "type": "inline",
+        "contents": "5b47f212fe504b3658e482fb881c82c2016419c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz\", \"integrity\": \"sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==\", \"time\": 0, \"size\": 9804, \"metadata\": {\"url\": \"https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b2ef5a84c2eaaa7d05e56b8cf6c031a281ad250ad82994ffd1323d790201",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/a1"
+    },
+    {
+        "type": "inline",
+        "contents": "5c025551726237eb9d4dcf3d21f6bce2afef7419\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz\", \"integrity\": \"sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==\", \"time\": 0, \"size\": 4866, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cc320bcdf637514aa94bc60116d1082ae1acf81835f508535c282a2b27fd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/25"
+    },
+    {
+        "type": "inline",
+        "contents": "5c4f51a477acdde316e0af0382ab3099f5713eda\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz\", \"integrity\": \"sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==\", \"time\": 0, \"size\": 15573, \"metadata\": {\"url\": \"https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "206a21191d0af92d124ee7a69e1a800e876063762b57ca00add7df413b4a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/36"
+    },
+    {
+        "type": "inline",
         "contents": "5c6bb9f96c8617d734c65bf9e9aa5a85fc9dacf2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz\", \"integrity\": \"sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==\", \"time\": 0, \"size\": 438175, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "958979caf6b1237ddd992bc3729955641114cff270020c7cfb9b99d5d206",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/d3/38"
     },
     {
         "type": "inline",
-        "contents": "5d4ec6a437038d973fee03754cde109060c05622\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz\", \"integrity\": \"sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==\", \"time\": 0, \"size\": 4030816, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "f350868a3d1245cdd7c203428627c0f1734196b855f35977b8706eba87e3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/44/99"
+        "contents": "5cca888d52e394a1ee0c14f4c765ee5f0bba2641\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz\", \"integrity\": \"sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==\", \"time\": 0, \"size\": 9935, \"metadata\": {\"url\": \"https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0b0f11cf02691485d52dd7cc936598ef0d703175fa5d39bae8aff085baeb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ef/9a"
     },
     {
         "type": "inline",
@@ -1085,45 +3622,57 @@
     },
     {
         "type": "inline",
-        "contents": "5f3da7d46fe1cbfc374b7390638dd7e1f6c7adba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz\", \"integrity\": \"sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==\", \"time\": 0, \"size\": 4613761, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "aafcdf067aa961755362313daffe661e288b16a349565c58bd60fc34c2d1",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/11"
+        "contents": "5e621ade89e852910872fb351d7f3083c1bcb416\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz\", \"integrity\": \"sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==\", \"time\": 0, \"size\": 2668, \"metadata\": {\"url\": \"https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "be90b3954e2f6e7b35b521e65a5016fd963aa11c3d6c88ccd9e0b61c069e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/ad"
     },
     {
         "type": "inline",
-        "contents": "616c1ffe0c3e48dcb6a35a27b93256d9709e5e7c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-9e4l6vy5qNSliDPqNfR6CkBOAx6PH7iDV4OJiEJzajajGrVy8gc/IKKJUsoE52G8ud8MX6r3PMl97NfwgOzB7g==\", \"time\": 0, \"size\": 7931575, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8dabc274a2c2dc7ef32d345a0d2b2edbd5dfe1fc8a299865fb0f92299d89",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/54"
+        "contents": "5e7f0fd740c47794cff337054a99ed4785744be0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-flat-config-utils/-/eslint-flat-config-utils-2.1.4.tgz\", \"integrity\": \"sha512-bEnmU5gqzS+4O+id9vrbP43vByjF+8KOs+QuuV4OlqAuXmnRW2zfI/Rza1fQvdihQ5h4DUo0NqFAiViD4mSrzQ==\", \"time\": 0, \"size\": 10147, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-flat-config-utils/-/eslint-flat-config-utils-2.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2aaae17ae9eda353b7b681869dc68e398cd3921a55c0feda722e8b2947cd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/0f"
     },
     {
         "type": "inline",
-        "contents": "62a6c0a659eab0c7e2628bc83dca89373035b702\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz\", \"integrity\": \"sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==\", \"time\": 0, \"size\": 4348595, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d0e24d50ec4d17a493d2bda7937612d44aabffbbb240ec1ef63e5b5f858e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2e/c6"
+        "contents": "5ec7c359c0b85c76a4044e368d387348de9f8ced\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz\", \"integrity\": \"sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==\", \"time\": 0, \"size\": 5512, \"metadata\": {\"url\": \"https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6d5c2061312fdd689bcc92e60ccf2b2e72bc15b7e22453f3a8680f491803",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/2c"
     },
     {
         "type": "inline",
-        "contents": "63b6f6d9ba78ae4d4893492e768c415cc5e5ae9c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-/L0htLJZbaZFL1g9OHOblTxbCYIGefErJjtYOwgl9ZqNx27P3L0SDfjhhHIss32gu5NWgnxuT2a2Hnnv6QGHKA==\", \"time\": 0, \"size\": 5958, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d19ecd47eda7723863379e64fa9013c530ee95cf9ec26385d1dd6c423291",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/73"
+        "contents": "5eeba38c32699bfe5489c58d29ded948619a20bb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\", \"integrity\": \"sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==\", \"time\": 0, \"size\": 2263, \"metadata\": {\"url\": \"https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "87042931e5944467d47331c350feb4384bf9143ab6ceebf7108a55905843",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/f7"
     },
     {
         "type": "inline",
-        "contents": "65e0185325b4e042bc21ed104dd5fa6830ded07f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-dDp7WbPapj/NVW0LSiH/CLwMhmLwwKb3R7mh2kWX+QW85X1DGVnIEyKh9PmNJjB/+suG1dJygdtdNPVXK1hylg==\", \"time\": 0, \"size\": 8516523, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "5f5d06a820c33b616b3f241a9d5344b842b06410b98d6686399247247205",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4d/fe"
+        "contents": "60f81decb0ef2499846809011578faf8768bab34\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz\", \"integrity\": \"sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==\", \"time\": 0, \"size\": 22400, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a825ea2c84ffbf55ba64f8df536ac984957d23e7273a8d5f50aa69e91a25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/c8"
     },
     {
         "type": "inline",
-        "contents": "66191be8bb31e34f64f1dbeb0ec2a8e005110c64\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz\", \"integrity\": \"sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==\", \"time\": 0, \"size\": 4248157, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "94fbdd3941d9eb645069d41f6d0f7da04d274922ec553e41f1eb22de5b06",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/38"
+        "contents": "615a58c968abb8ace24f4440b2df229fee638669\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz\", \"integrity\": \"sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==\", \"time\": 0, \"size\": 5065, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3977f30ccffa4b15f3b8e0dcfdba105dadf0c0eb5e8263e3c12dea6165ee",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/af"
     },
     {
         "type": "inline",
-        "contents": "668c12fccba5cc5bfb59f4e51e056b76869c2ef1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-1BNQW8u4ro8bsN1+tgKENJiqmvc+WfuaUhXzMImOVSMw28pkBKdfZtX2qJPADV3terx+vNJtlsgSGeb3+W6Jiw==\", \"time\": 0, \"size\": 8040550, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "4c2448e723636066145d1573828d37a76e3abd86b589f86896af4b9692de",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/3f"
+        "contents": "63a8770cdbfd647f876967ab01ae3a92eb632755\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz\", \"integrity\": \"sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==\", \"time\": 0, \"size\": 318961, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "afd4aa090b087c509f17e75196209f498c916da50ee4e9f26bd8424fd6f7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/cc"
+    },
+    {
+        "type": "inline",
+        "contents": "655f889e5fe96f030cc3ab09eda0d341e98115cd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz\", \"integrity\": \"sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==\", \"time\": 0, \"size\": 3640281, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "46e27f0cbd5833bc87728ef4e40bb9ef5439c5f0f1006efe6ffc62ff83be",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/91"
+    },
+    {
+        "type": "inline",
+        "contents": "6795c0c84c6a04697d3efe79e25fab31b121f163\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz\", \"integrity\": \"sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==\", \"time\": 0, \"size\": 6145, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "29a46658abf61c9719df02da136c280351a126f4bf1dfded33238ec0f0f5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/6b"
     },
     {
         "type": "inline",
@@ -1139,15 +3688,63 @@
     },
     {
         "type": "inline",
+        "contents": "682cb5224e4e0e1b8cb5b6da78b133877cfac892\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz\", \"integrity\": \"sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==\", \"time\": 0, \"size\": 3310, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "51691c7fc56f6e026e299c869bc807d4902be0025d2cbe18e615d1c040ca",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/eb"
+    },
+    {
+        "type": "inline",
+        "contents": "684cae2eb237afe3b983be0f21c8da5a2b0b8401\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz\", \"integrity\": \"sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==\", \"time\": 0, \"size\": 4365103, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f3478b8c27f8389d20c885ea193679b4faef49a3a77acfa6e212b8652c1d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/76"
+    },
+    {
+        "type": "inline",
+        "contents": "6ae479fdda388f87da96279394dbabd3e81028fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz\", \"integrity\": \"sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==\", \"time\": 0, \"size\": 8053, \"metadata\": {\"url\": \"https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fb3e170f2cf1d4fa8032d577b0260b5a8784aadbb9e7dfd68dc0cd3c38a9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/29"
+    },
+    {
+        "type": "inline",
         "contents": "6bb73486f2ec97d9a896c101c6cba11334e136d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz\", \"integrity\": \"sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==\", \"time\": 0, \"size\": 85561, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "f394cacdcdca2aae8dfa200c52264fd433db7075a846c98a8df037496049",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/16"
     },
     {
         "type": "inline",
-        "contents": "6cd1679d0ed50c48d45e8dee28841abb8508a22e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-V48oDR84feRU2KRuzpALp594Uqlx27+zFsT6+BgTcXOtu7dWy350J1G28ydoCwKB+oxwsRPx2e7aeQnmd3YJbQ==\", \"time\": 0, \"size\": 8073483, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b3f559fc96de6524400618b06fefcb55742d98e4111850ba0c5ffccb4600",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/80/ff"
+        "contents": "6c207587cf34c6eae0632aacbc4b71b0645df26e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz\", \"integrity\": \"sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==\", \"time\": 0, \"size\": 8903, \"metadata\": {\"url\": \"https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0184937fde98938cb062ec8293fb6a17fcb7da8963a6d525de3f86b642e5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/6e"
+    },
+    {
+        "type": "inline",
+        "contents": "6c351d2fffd1d44fd4890a087159c635b59b10dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz\", \"integrity\": \"sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==\", \"time\": 0, \"size\": 183645, \"metadata\": {\"url\": \"https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7a34dc4a22d8ce5b33d31c3998baafb19dc8fb04885aa3f2e0a2a46497d4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/c2"
+    },
+    {
+        "type": "inline",
+        "contents": "6c4e646cf32bbf59b465e310a7f8c9853168cec7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz\", \"integrity\": \"sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==\", \"time\": 0, \"size\": 2895, \"metadata\": {\"url\": \"https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "491dd7a4dbb4ca6674bc806f768829f36d44790e674c00b1ab860de4ccbd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/56"
+    },
+    {
+        "type": "inline",
+        "contents": "6cf594d613c1f32ce3679cea457a05cfb7cefb65\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz\", \"integrity\": \"sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==\", \"time\": 0, \"size\": 4246, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9305c09d5789a41fefc7aa0cd3a8a3813243d247f506487c2f66e9ff5971",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/3c"
+    },
+    {
+        "type": "inline",
+        "contents": "6d59684f2045d6d209fe93ffc2fb7ec662adf4cc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz\", \"integrity\": \"sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==\", \"time\": 0, \"size\": 6495, \"metadata\": {\"url\": \"https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d9d201a5b440cf5e3d9fe4fd277d173efc5975b1a84bfc4f5eec4cb9da6f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/12"
+    },
+    {
+        "type": "inline",
+        "contents": "6f699bc5c24128d527ad817a6867284b656c0495\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@antfu/eslint-config/-/eslint-config-6.7.1.tgz\", \"integrity\": \"sha512-+8GIMmOfrtAVXoqVK9sfovAlHPkp35ilntqZ6XloO/Rty36gOxaa8dvwCh8/eqwwIsloA/hDJo3Ef95TRbdyEg==\", \"time\": 0, \"size\": 219174, \"metadata\": {\"url\": \"https://registry.npmjs.org/@antfu/eslint-config/-/eslint-config-6.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b314c284b4e5ab420cd8a0cbaddd00be85ac602213d7e06e4ee7463ce9d4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/71"
     },
     {
         "type": "inline",
@@ -1157,33 +3754,99 @@
     },
     {
         "type": "inline",
+        "contents": "701083ce922d2a9ed37a3d4b837fdb151848728c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz\", \"integrity\": \"sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==\", \"time\": 0, \"size\": 10905, \"metadata\": {\"url\": \"https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4ca8cca9a6a1bca0f08f5bd01fcb65c2f8278c1bcdc84b6c84ec4212b0e7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/9c"
+    },
+    {
+        "type": "inline",
+        "contents": "70ca298fdfd6b1156ddaee99088279de677f878a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz\", \"integrity\": \"sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==\", \"time\": 0, \"size\": 7170, \"metadata\": {\"url\": \"https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8fa36c67780841502e2f629296436967de1ee24ce39471995f6d8d5b46d8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/45/0a"
+    },
+    {
+        "type": "inline",
         "contents": "719ea523cc47269953393542ba84568bc220dac4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz\", \"integrity\": \"sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==\", \"time\": 0, \"size\": 35340, \"metadata\": {\"url\": \"https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "1018bd2617c9bf8a0c2742b8d6db95d9995670b0e195cb06cfea9d61c009",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/e3"
     },
     {
         "type": "inline",
-        "contents": "757d54b040b8fc14b642dec4b125ad8a8f6ae256\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-UuA+JqQIgqtkgGN2c/AQ5wi8M6mJHrahz/wciENPTeI6zEIbbLGoth5XN+sQe2pJDejEVofN9aOAp0kaazwnVg==\", \"time\": 0, \"size\": 8542150, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "38459ed28bbf5897122fb78236dde917d79f8912c8d50113d181e5b009f7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/e6"
+        "contents": "721b539f349c8a4049c23b09158a3e5d1b131d0c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz\", \"integrity\": \"sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==\", \"time\": 0, \"size\": 201653, \"metadata\": {\"url\": \"https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "26df9cfb5a843dd373b6b2e3a7aae5ca0de5cf19b9a2dae2cbd6395e236c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/31"
     },
     {
         "type": "inline",
-        "contents": "7662279a135e058d53ae53fde98baa16d02d9050\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz\", \"integrity\": \"sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==\", \"time\": 0, \"size\": 4389650, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "da720d4cb64ed5db740432cfe6ef7642e5a9c7d5681e2d5cdf9e6a470c0c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/64"
+        "contents": "72e9cf214d7c66771346a2fad27886466c99f6dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fault/-/fault-2.0.1.tgz\", \"integrity\": \"sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==\", \"time\": 0, \"size\": 4008, \"metadata\": {\"url\": \"https://registry.npmjs.org/fault/-/fault-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c8191b0bed36d36222258b01d08acbf1891968aa6fde5862ab74c8ad9801",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/c8"
     },
     {
         "type": "inline",
-        "contents": "78ef0f48d6d90b5de6820f49d199afa48ebff840\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-qpHedvQBmIjT8zdnjN3nWPR2qjQyJttbXniCEKKdHeAbZG9HyNPBUzQF7AZZGwmS9coQKL+hWg9FhWzh2dZ2IA==\", \"time\": 0, \"size\": 8223139, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3554d92ca01c4e51e314f01514d3072f9a9438bf71b98c642a4fe17c785d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/88/5b"
+        "contents": "74560968a3ed8d106fe6730ef81d661e676bb88d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-toml/-/eslint-plugin-toml-0.12.0.tgz\", \"integrity\": \"sha512-+/wVObA9DVhwZB1nG83D2OAQRrcQZXy+drqUnFJKymqnmbnbfg/UPmEMCKrJNcEboUGxUjYrJlgy+/Y930mURQ==\", \"time\": 0, \"size\": 30817, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-toml/-/eslint-plugin-toml-0.12.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "15508b1bf564ec8ff6bcc4f940df549ff0e9d3bee895df83fc5f3dcf34d5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/23"
     },
     {
         "type": "inline",
-        "contents": "7b270ed2db296c2bf6707f143b2233f76db9e6a7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz\", \"integrity\": \"sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==\", \"time\": 0, \"size\": 4556098, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3d24479ab031099a7c9633f26834901c777c4c0ab23bfa7aa479b38e5966",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/9e"
+        "contents": "7590d644854430ceb3d166d6a10b762f962fd1f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz\", \"integrity\": \"sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==\", \"time\": 0, \"size\": 1506, \"metadata\": {\"url\": \"https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0ff11cd5c49f9abb3792227a2806421aeb4003688278322146dd805a2cea",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/31"
+    },
+    {
+        "type": "inline",
+        "contents": "763f5ac7f2031944fba31714ab8d0da0f1215ea0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-import-lite/-/eslint-plugin-import-lite-0.3.1.tgz\", \"integrity\": \"sha512-9+EByHZatvWFn/lRsUja5pwah0U5lhOA6SXqTI/iIzoIJHMgmsHUHEaTlLzKU/ukyCRwKEU5E92aUURPgVWq0A==\", \"time\": 0, \"size\": 13629, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-import-lite/-/eslint-plugin-import-lite-0.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8263b32180fa4dd8f0f130ca762b34a2ca0d5e5433829dc429d9c47a232a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/06"
+    },
+    {
+        "type": "inline",
+        "contents": "7641368474869040e3961b45f849d8efca03e063\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz\", \"integrity\": \"sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==\", \"time\": 0, \"size\": 39740, \"metadata\": {\"url\": \"https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "339b9832e323abb280eb874ec64f59486423026430be7b1c2ec42ca7e1b7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/6b"
+    },
+    {
+        "type": "inline",
+        "contents": "76d15e025c33eaa4efa2fa1a68a418559047128e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz\", \"integrity\": \"sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==\", \"time\": 0, \"size\": 4516779, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ee35b2a7edeb5e1f2db5a0941d10fbb21324a85b4082e78fa37c553776ce",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/3e"
+    },
+    {
+        "type": "inline",
+        "contents": "77029c495e22db94691e530b0901a24ef1909fd7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz\", \"integrity\": \"sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==\", \"time\": 0, \"size\": 13081, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2491a48f50be25a8213ee0a1186e48b2141688c4b926158ec064dbee258c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/3f"
+    },
+    {
+        "type": "inline",
+        "contents": "77148f96f858b14a66ff06259cab16cd02f0247c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz\", \"integrity\": \"sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==\", \"time\": 0, \"size\": 4928, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7f76bc366341c7541dad7672975592c702ee7d0620f09dcad0a2f62213da",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/ba"
+    },
+    {
+        "type": "inline",
+        "contents": "77a1d1ae6f7f7e2298a2412ea3b11ee7a89a652c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz\", \"integrity\": \"sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==\", \"time\": 0, \"size\": 30946, \"metadata\": {\"url\": \"https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5be0749ad82d23c11b1a11e365169ad8f7ce212c313076e163775be0ca68",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ad/f6"
+    },
+    {
+        "type": "inline",
+        "contents": "79c37afa95dfeffc58d86bf3410ee152175e6a67\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz\", \"integrity\": \"sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==\", \"time\": 0, \"size\": 5194, \"metadata\": {\"url\": \"https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "639107e3f13a812eb6cb868ab09827c1e4a913b741a0db28c7b348e62204",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/d0"
+    },
+    {
+        "type": "inline",
+        "contents": "7a96398bcb23418943af4f6b2a22a767399e981b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/debug/-/debug-4.4.3.tgz\", \"integrity\": \"sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==\", \"time\": 0, \"size\": 13449, \"metadata\": {\"url\": \"https://registry.npmjs.org/debug/-/debug-4.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e25f670d26bc26d1cb236efef449fc8718223fd484c4107ba797934cb10c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/1f"
+    },
+    {
+        "type": "inline",
+        "contents": "7b6ef4857d8cb7056609900e8a97ccb54c436b14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz\", \"integrity\": \"sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==\", \"time\": 0, \"size\": 4625395, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d03203f52caf948e023990708c2d214b3fd9d2012d2edb9d1f0d5eac24f0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/34"
     },
     {
         "type": "inline",
@@ -1193,9 +3856,33 @@
     },
     {
         "type": "inline",
-        "contents": "7d5e83222b75714e771df7b43010dac2bf5b860e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-U3ZL1ksrp/Go+8XG4M2eWoqhejK9v74WHWZ7FuXii1YUlcRTbFdtrNDuYwW9bCymN29VH91/rT32o5i266hPrg==\", \"time\": 0, \"size\": 11074, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1853ddedc15d9aeb97d391f9aa1240d87d8800b06f5f1004e952ff6ff02f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/d9"
+        "contents": "7c442e6fcb2e842a764f9b558be2907f1e4db8d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz\", \"integrity\": \"sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==\", \"time\": 0, \"size\": 8620, \"metadata\": {\"url\": \"https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "35cb8b23ae64f5467e4748e13214ac6208cf6c4330e3bc5a2a28b7b96aac",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/ed"
+    },
+    {
+        "type": "inline",
+        "contents": "7caaf9a9ec61fb3fc742812007d200f1f9b42a36\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz\", \"integrity\": \"sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==\", \"time\": 0, \"size\": 17729, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "15ef953fbc6f0f7cfac2cdf0b1819074586d942cf0e1094781f97a9f6e83",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/62/ff"
+    },
+    {
+        "type": "inline",
+        "contents": "7d1209c0e455f51be51390ff5b43f3d4e2eb6297\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-bpIGX+ov9PhJYV+wHNXl9rzq4F0QvILiURn0y0oepbQx+7stmQsKA0DhPGwmhfvF856wq+gbM8L92SAa/CBcLg==\", \"time\": 0, \"size\": 8097367, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e5b6ae99a6fa4e9e869506dc7f3c2fb005db321bf886e13837a73da1080e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/54"
+    },
+    {
+        "type": "inline",
+        "contents": "7ddafcb73a2e6f9bf126cdb16c87735c6e4dc015\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz\", \"integrity\": \"sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==\", \"time\": 0, \"size\": 4621, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7c9e3404de9212aefe3706d0ad202a663b6af36dcd7532e19428d480a26",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/02"
+    },
+    {
+        "type": "inline",
+        "contents": "7efc93bef9ef5490b3c71d076756b7397ceded9f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz\", \"integrity\": \"sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==\", \"time\": 0, \"size\": 6109, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f8b9e34ac6d6ef95428dad3e387bb5d548ff855da3fa4aefcde32e9b8437",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/f1"
     },
     {
         "type": "inline",
@@ -1205,15 +3892,45 @@
     },
     {
         "type": "inline",
-        "contents": "81d3c963d72b067bcd33fac7c4bae35efde25032\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz\", \"integrity\": \"sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==\", \"time\": 0, \"size\": 4243222, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "14f60fd271ce932c2af1751cad08dcb7aa420743d9c392c9bf0d91e77153",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/92"
+        "contents": "807f8d5cc30e3a64c7877f5254c268b611a6ec9c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz\", \"integrity\": \"sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==\", \"time\": 0, \"size\": 35815, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0564f4e8aad574c48d6ac7e5653a9bbd7077c5801249a133db9388e33158",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/02"
     },
     {
         "type": "inline",
-        "contents": "845125ee8b3c4a1e88b20dcace61cb5ffed0f5a1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz\", \"integrity\": \"sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==\", \"time\": 0, \"size\": 3638272, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "417e2f2c3efaca215d4a6d4295bc346fe79d9f3760f4482a609cf832c836",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/c8"
+        "contents": "815672e08e8f20f99d5d42c0a95505e152116b4a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz\", \"integrity\": \"sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==\", \"time\": 0, \"size\": 3954, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "daead60c0f2b36a2f438aebd7254c1eecd0ad443b8727e2ecd0b96a36fee",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/89"
+    },
+    {
+        "type": "inline",
+        "contents": "81bb4dc5ae74582b60bab7fab99f69aca80bbfa8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz\", \"integrity\": \"sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==\", \"time\": 0, \"size\": 10659, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a58617bf598657c0982eca04dd9ba7d1492c795683d12ff2dee18a2193ff",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/e8"
+    },
+    {
+        "type": "inline",
+        "contents": "8292395391bc61b0096826abcf294b433419f659\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz\", \"integrity\": \"sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==\", \"time\": 0, \"size\": 2597, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2940db4424ac48633f9098ec17a31aef19d4addb5682eac80e6137266bcb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/ad"
+    },
+    {
+        "type": "inline",
+        "contents": "82d09144fc440ea901f33d2f5d60f765edcf4ddf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz\", \"integrity\": \"sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==\", \"time\": 0, \"size\": 2510, \"metadata\": {\"url\": \"https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9bf57dceb99b6a930d3ad84cbe70e19fad1250d13e828e2b3c4c491b3994",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/11"
+    },
+    {
+        "type": "inline",
+        "contents": "8388e2b36a09734d23b5642134274c7b6f07402a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz\", \"integrity\": \"sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==\", \"time\": 0, \"size\": 14260, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "68efe1e600e8fba26ef09d0b0238a5700c8a3c1a157737b73afe19141f8c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/29"
+    },
+    {
+        "type": "inline",
+        "contents": "8510d45e956649a19ab215c4d9dffa735289ac4e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.3.0.tgz\", \"integrity\": \"sha512-5hI5NCJwKBGtzWtdKB3c2fOEpI77Iaa0z4mSzZPU1cJ/OqrGbFafm90edVCd7T9Snz+Sh09TMAv4EQqyVLzuEg==\", \"time\": 0, \"size\": 537717, \"metadata\": {\"url\": \"https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f671f22c731051266b3099f260227803e406debd0dd6340151961f2bb248",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/9a"
     },
     {
         "type": "inline",
@@ -1223,27 +3940,51 @@
     },
     {
         "type": "inline",
-        "contents": "86a7862e6ecf7e83b4f5d637191d9e0d04b6ae33\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-K/p7clhCqJOQpXGykrFaBX2Dp9AUVIDHGc+PtFGBwg7V+mvBTv/tsm3LC3aUmH02H2y3gz4y+nUTQ0MLpofEEg==\", \"time\": 0, \"size\": 3534310, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "8713ba73a9e323ec90d9b51fed5a8015d087b1e69e72c66824c68ebf3a4f",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/db"
+        "contents": "854c1c21b1f2b11ecf022e52956952fc85b6cd71\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz\", \"integrity\": \"sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==\", \"time\": 0, \"size\": 4079, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9e5d0a79b62753061b049dab16f2f233f1aeb0957269670018169608928c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/98"
     },
     {
         "type": "inline",
-        "contents": "8b1f5c554bb71717b6c2a416926f7efc6bf49c98\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz\", \"integrity\": \"sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==\", \"time\": 0, \"size\": 4415041, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "7b9058dab64efb5bf230beb2205024268cedd66565ae3ee4233ed187b312",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/9f"
+        "contents": "87114ba233a2f390dad2ea779bb91aa8f1cc9931\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz\", \"integrity\": \"sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==\", \"time\": 0, \"size\": 7635, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5b88cf3c6125d3f0a83e08d7fc6bc3848a7da209ed87f32d58376e0c2224",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/a9"
     },
     {
         "type": "inline",
-        "contents": "8b3173990061dc6471a75ba9f186b1a78fda3c92\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-Hbnpljue+JhMJrlOjQ1ixp9me7sUec7OjFvS+A1Qm8k8Xyxmw3ZhxFu7LlSXW1s9AX3POE9W9o2oqCEeR5uDmg==\", \"time\": 0, \"size\": 118551, \"metadata\": {\"url\": \"https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "b6ad45d7a206702a6b7c31fa088b4e941d9df8f10acb646ba52a0330493e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/e6"
+        "contents": "895829cdcca32865221dc564f53ee1024a2835f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-processor-vue-blocks/-/eslint-processor-vue-blocks-2.0.0.tgz\", \"integrity\": \"sha512-u4W0CJwGoWY3bjXAuFpc/b6eK3NQEI8MoeW7ritKj3G3z/WtHrKjkqf+wk8mPEy5rlMGS+k6AZYOw2XBoN/02Q==\", \"time\": 0, \"size\": 3971, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-processor-vue-blocks/-/eslint-processor-vue-blocks-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "13da1f6e840862da888659612aa00587f26809522a133bff975ad4eced75",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/19"
     },
     {
         "type": "inline",
-        "contents": "8cac65eeb34ad3a2ee5f7d45a86960218a1f3a08\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-cfclByH3KXzqxBImIX8dlTLI3bozj993RWCFv3MTnTMPkeWa7Hh9qPXwfFfyw9TO5OHYO9rWnFw+DLxcBVFUzQ==\", \"time\": 0, \"size\": 111663, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "79963b63f35ccee0c2d44cc09be0af4cbaaa6eabff05625e64b0f4fbc2da",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/b2"
+        "contents": "89f7dc57a4eb95d8b28828e8837ecb7b4b488378\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz\", \"integrity\": \"sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==\", \"time\": 0, \"size\": 5324, \"metadata\": {\"url\": \"https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ecdd467f90433d327bb6801669b84d80924c420f37b3ee75069f116fc263",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/38"
+    },
+    {
+        "type": "inline",
+        "contents": "8a0aed2908d92e38915c99a5021c30921a5257ca\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==\", \"time\": 0, \"size\": 8565919, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4fa33b9044be13d90cb00b613917dd8cbf774f0e92fab8d1b9d71fa95a24",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/43/7d"
+    },
+    {
+        "type": "inline",
+        "contents": "8ac85d5cb1e56d47ae184e0bcf098415c810f495\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz\", \"integrity\": \"sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==\", \"time\": 0, \"size\": 18844, \"metadata\": {\"url\": \"https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0263576d4c85bdff52fac6d96619789061662d4b6b3cee7566631d26ae5b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/f8"
+    },
+    {
+        "type": "inline",
+        "contents": "8b803f7bd2896dcc2a4d51166dad8535838fbd8f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz\", \"integrity\": \"sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==\", \"time\": 0, \"size\": 95174, \"metadata\": {\"url\": \"https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "487c86743ff85773f81174888b881f6646009713a7e92294daac8eda4c73",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/99/f8"
+    },
+    {
+        "type": "inline",
+        "contents": "8d43898a0964982a55f9939bc850ca41a4bac416\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz\", \"integrity\": \"sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==\", \"time\": 0, \"size\": 16037, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "60d3825debdff5bbc2b3f03c05e58f8de1588a9ed67064de33c1f899e934",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/93"
     },
     {
         "type": "inline",
@@ -1253,27 +3994,147 @@
     },
     {
         "type": "inline",
-        "contents": "8e853bd26bd86f733783a53296e0a9b75266a669\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@oxc-project/types/-/types-0.99.0.tgz\", \"integrity\": \"sha512-LLDEhXB7g1m5J+woRSgfKsFPS3LhR9xRhTeIoEBm5WrkwMxn6eZ0Ld0c0K5eHB57ChZX6I3uSmmLjZ8pcjlRcw==\", \"time\": 0, \"size\": 7748, \"metadata\": {\"url\": \"https://registry.npmjs.org/@oxc-project/types/-/types-0.99.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2989545c48d810e5316096add2a73b35013d0c8a0604c3e030b773ff4c26",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/78"
+        "contents": "8db6926ed79aca9cc1c9797481c858b4ae9e9b81\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz\", \"integrity\": \"sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==\", \"time\": 0, \"size\": 51436, \"metadata\": {\"url\": \"https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "be99d19f8d83f5ca5317dded12dd1129124c2ad1ec2b1e1c7ddb60a65c7c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cc/a6"
     },
     {
         "type": "inline",
-        "contents": "95acbb3bcc3a7a0dac0d87451b93aa963cbd4bf1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-+2cBaoBTHhLjOsgROPfnuw+DQ/HTFB/r3E81DMsZF1Z2FiyLSrowbMTxJMdY8bHA/H0ibqMCUePNl5EI7A9tdA==\", \"time\": 0, \"size\": 235135, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/compiler-vapor/-/compiler-vapor-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "fa92ede1c57a47092197609cdf26badaada210c31d5318ddf6eae918de66",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/2e"
+        "contents": "8e35cb1dbcb55dbd8bcce7ed3c10308b220f245f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz\", \"integrity\": \"sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==\", \"time\": 0, \"size\": 22477, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "70f2d09e88b52e50b4f2f83eb4d09a8274b46984806a4934f47e709dcf86",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/a5"
     },
     {
         "type": "inline",
-        "contents": "95bfe1e3dfe47c9dd1de3996509cc866307dc444\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.2.tgz\", \"integrity\": \"sha512-iHmwV3QcVGGvSC1BG5bZ4z6iwa1SOpAPWmnjOErd4Ske+lZua5K9TtAVdx0gMBClJ28DViCbSmZitjWZsWO3LA==\", \"time\": 0, \"size\": 25319, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "72f71cb8a5ce1ad5e40425b2a121af77c775d09b25b8a203d100efe1c1c7",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/b9"
+        "contents": "8e70c1566d2a126d311d3224316e888924d7606c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz\", \"integrity\": \"sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==\", \"time\": 0, \"size\": 3265, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8a67a6a69c573e507dac8723fa56c0451c1ebb42aa08925c3bd37a8435c3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "8e78f6d43fc49a7f01653ad46ff81d8e3033df57\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz\", \"integrity\": \"sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==\", \"time\": 0, \"size\": 4315, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "621d9ca493cc662d29c56889ae68f8de7b4efaf3d40fdbf8de0f3b70bc38",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bc/bf"
+    },
+    {
+        "type": "inline",
+        "contents": "8f918232876800e8eeffb17ac191c06877b1614c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz\", \"integrity\": \"sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==\", \"time\": 0, \"size\": 51777, \"metadata\": {\"url\": \"https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8d2045a4a64e1616766f776adbcb349104b5c6c829fbc25c7b829d95a297",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/29"
+    },
+    {
+        "type": "inline",
+        "contents": "90fc7ecf7274ddf541e452c1f9b936bc17df7238\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz\", \"integrity\": \"sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==\", \"time\": 0, \"size\": 7603, \"metadata\": {\"url\": \"https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7f7a0679c52edb767a55df3d93f847884d7909cf16c2f148ba11d53e9f7c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/ea"
+    },
+    {
+        "type": "inline",
+        "contents": "918af0b588e7f7f415b9559cc269af33de193780\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz\", \"integrity\": \"sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==\", \"time\": 0, \"size\": 13110, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c23c5b58fa29a0f581817f5da27d12054e075316b20457880fbb752cc252",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/e6"
+    },
+    {
+        "type": "inline",
+        "contents": "91b88e3ca2722e4c9cf4a98bfc1d7687104c9b9f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz\", \"integrity\": \"sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==\", \"time\": 0, \"size\": 40749, \"metadata\": {\"url\": \"https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "92ca35b50f14a6d8b44d07faea194c602a5fb8ae41ce077e0538087a3d3d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8c/5c"
+    },
+    {
+        "type": "inline",
+        "contents": "91ca3f43418db12aee2ae28ba29ddee202ae3c96\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz\", \"integrity\": \"sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==\", \"time\": 0, \"size\": 12184, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a5c71d414e305b0166e5c8b5764d1641a507377b4bdb3d9a5d9793c63002",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c2/12"
+    },
+    {
+        "type": "inline",
+        "contents": "91cf859a57821d613590397910a610fa21e3daec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"integrity\": \"sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==\", \"time\": 0, \"size\": 6255, \"metadata\": {\"url\": \"https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e41f2c2713684e6e809753f5b2a642d98d5d19a1c17c03d0788531cebf88",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/7f"
+    },
+    {
+        "type": "inline",
+        "contents": "9256c05809b130d5104ba822f57e889480cd5e45\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz\", \"integrity\": \"sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==\", \"time\": 0, \"size\": 43182, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fdd901bf99d7fe725a565c4454f0b7ee6dc3b3fc9babcb0f77ab8498cfa0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/58"
+    },
+    {
+        "type": "inline",
+        "contents": "9259bdf6859dd96090043e26d571bb40dab1c716\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz\", \"integrity\": \"sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==\", \"time\": 0, \"size\": 4557102, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "53b8188ff94c03e04f69e187f28e2cf6e62e6a134135a6dced9cb809b3c1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/76"
+    },
+    {
+        "type": "inline",
+        "contents": "92794c8762e4ce2a6efb9e1bc12eb426956cf058\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz\", \"integrity\": \"sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==\", \"time\": 0, \"size\": 8095, \"metadata\": {\"url\": \"https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "702f8d96c9a2c0092eb1ea648d66ca6963627fdb21b277f7ef2dddf59d00",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/4b"
+    },
+    {
+        "type": "inline",
+        "contents": "92ef7da4f685312682eaad0c0b8d87fe72918c2c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz\", \"integrity\": \"sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==\", \"time\": 0, \"size\": 34540, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4f670bf8b52171cffed1ff196b49748529ed1e11d3ac65278192acba856b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/f0"
+    },
+    {
+        "type": "inline",
+        "contents": "94157a609fe722c2ce8e371484bd9efe98ff2efd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz\", \"integrity\": \"sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==\", \"time\": 0, \"size\": 9542, \"metadata\": {\"url\": \"https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "db09e99d2fc4b9d471366260d48b659687fefb56966562f29c82112f99a9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/f9"
+    },
+    {
+        "type": "inline",
+        "contents": "94af6cc718f0203e528121d61174bf19ea4583a1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.1.tgz\", \"integrity\": \"sha512-YzEodbDyW8DX8bImKhAcCeu/L31Dd/70Bidx2Qex9OFUtgzXLqtfWL4Hr5fM/aCCB8QUZLuJur0S9k6UfgFkfg==\", \"time\": 0, \"size\": 7437, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7b82b12e6eba7ed274756141c82a74b3d756598fc2d394b6de4dedb30f76",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/6e"
+    },
+    {
+        "type": "inline",
+        "contents": "94b8d6a4c5f1545ef6e579d9f7fde82cc95af232\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"integrity\": \"sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==\", \"time\": 0, \"size\": 3756, \"metadata\": {\"url\": \"https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7afbc9eb60823c417e5dd1dd2f56b61e1b85cdd840120ff5644e6b03358",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/76"
+    },
+    {
+        "type": "inline",
+        "contents": "94d83470a818bce8ae37e2a14e1679f57614c44c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz\", \"integrity\": \"sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==\", \"time\": 0, \"size\": 107004, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dbbf3a37a2f7f776ba615018d4a4a24bcc96028c9415ae011e013c1e08a0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/4f"
+    },
+    {
+        "type": "inline",
+        "contents": "959686a04ba543c6a1028b09890f38b082c9480d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz\", \"integrity\": \"sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==\", \"time\": 0, \"size\": 10514, \"metadata\": {\"url\": \"https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dd764f9157e62a44b691eb51c0a1d8991d12555a4c399af60fb929b0fd4f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/fe"
+    },
+    {
+        "type": "inline",
+        "contents": "9599017eca488754d3be557bbe04cabf07992795\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz\", \"integrity\": \"sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==\", \"time\": 0, \"size\": 14017, \"metadata\": {\"url\": \"https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "03efc199c2b017a7533cc730722dec616ebc1b3be56bda4c0a85c7f71fa6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/01"
+    },
+    {
+        "type": "inline",
+        "contents": "95c85b01c4ceaad240bbc82f4dc154434490df21\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz\", \"integrity\": \"sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==\", \"time\": 0, \"size\": 4225, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cd37fdbc30555b3da41894e3ba655757d3cf62b69063e7624406ea17b115",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/86"
     },
     {
         "type": "inline",
         "contents": "97278789da91610b2bd8f852f7e40a48820684d5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.25.tgz\", \"integrity\": \"sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==\", \"time\": 0, \"size\": 143853, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.25.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "c2c6669df9a0e5fe55824317a2ded6f1df5faea6b3e7e3c1f1d341cf1496",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/0c"
+    },
+    {
+        "type": "inline",
+        "contents": "98b81300b1b705fbc86bb100b6d42330dde8b201\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==\", \"time\": 0, \"size\": 8130412, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1387daa5f03dd7c4323f5155a399c5589a56ba53958fdde259909e6aa472",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/44/82"
+    },
+    {
+        "type": "inline",
+        "contents": "98ccaee5f8ce2817a09b90e28ebe806a75f4a606\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz\", \"integrity\": \"sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==\", \"time\": 0, \"size\": 2868, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d04e75208dec117f72a95a5989f81fac7565a530fd22f70ea5e3abc377c3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/62"
     },
     {
         "type": "inline",
@@ -1289,9 +4150,33 @@
     },
     {
         "type": "inline",
-        "contents": "9d7cdc83ea68badef55956cfc10878ae9c43fba2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz\", \"integrity\": \"sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==\", \"time\": 0, \"size\": 4185426, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "d875b1e19ba82ededcc70f7b4dae457448eacbf9d80e54ffa1d2d48d7e1d",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/c5"
+        "contents": "9a649a725d9066ce7fb08189a41b4c930555eee1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz\", \"integrity\": \"sha512-ritPSKLBcParnsKYi+GNtbdbrIE1mtuFEJ4U1sWeuOMlIziK5GtOL85t5RhsNy4uWIXPgk+OUdpnXiTdzn8o3A==\", \"time\": 0, \"size\": 11183, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b9ae87df61919c4dd05c8267d33d628af336ac068faca4621a5bd0a6243b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/68"
+    },
+    {
+        "type": "inline",
+        "contents": "9abfb23653757e8801541bd489373525c970dfdb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz\", \"integrity\": \"sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==\", \"time\": 0, \"size\": 4844, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a74e39e810e5e64eeeeb270673e04f6bac066f4bba7cae33536e1ff15844",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/69"
+    },
+    {
+        "type": "inline",
+        "contents": "9c5440bf4507f9cf749bc4c1c07f28f844964972\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz\", \"integrity\": \"sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==\", \"time\": 0, \"size\": 37826, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dc7b2960f40e996d884e1dbde12c260f665d0e03272031204f5dfb6cda31",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/53"
+    },
+    {
+        "type": "inline",
+        "contents": "9c8a850b9eef6b34ef0ed7687dee7ce92ac997b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ms/-/ms-2.1.3.tgz\", \"integrity\": \"sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==\", \"time\": 0, \"size\": 2967, \"metadata\": {\"url\": \"https://registry.npmjs.org/ms/-/ms-2.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bd8af8e4938b9fee217abddb09ce52db330434e323c828aeabe5bd909ae7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/a7"
+    },
+    {
+        "type": "inline",
+        "contents": "9cf2010228c8a084bff565a9e8996d8c6da4db19\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz\", \"integrity\": \"sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==\", \"time\": 0, \"size\": 4445, \"metadata\": {\"url\": \"https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d05a4ca356bacc2043505cf69fcf92d0b0a1220ef2dcb2ee35b8ce561177",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/b2"
     },
     {
         "type": "inline",
@@ -1301,21 +4186,159 @@
     },
     {
         "type": "inline",
-        "contents": "a2f3742c49552507c7f10887a6254969ff5884b4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.2.8.tgz\", \"integrity\": \"sha512-8wKihlF6EDF8grimwd7GPOhLkQkSIgj6Hlcp0CXhtO3HAXeUUqhgZmJmn07OF8e4PbTusMX6Yxmy1BptVRZsdw==\", \"time\": 0, \"size\": 537534, \"metadata\": {\"url\": \"https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1802e69a6d16a1b3668baec1f7c012e5441ea5262a1c19f19ab67a856fb3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/13"
+        "contents": "9e2832ec9904f1cce33cb05ec2faf5f4da48355c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.6.2.tgz\", \"integrity\": \"sha512-nA5yUs/B1KmKzvC42fyD0+l9Yd+LtEpVhWRbXuDj0e+ZURcTtyRbMDWUeJmTAh2wC6jC83raS63anNM2YT3NPw==\", \"time\": 0, \"size\": 280680, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f28c54699da80f6e412428ffe02b0c313c8866869fb0bdad1361aeeff4fe",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/c2"
     },
     {
         "type": "inline",
-        "contents": "a69a60bab2bd85b4941ec24e53bab9f50aba58cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz\", \"integrity\": \"sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==\", \"time\": 0, \"size\": 586920, \"metadata\": {\"url\": \"https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ef4be9962ecc16f774b8598b82de818d16d148e7e45bfa6c5973e474af46",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/8a"
+        "contents": "9f85c31c13764f8a36a7a01014c392196c806b8d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz\", \"integrity\": \"sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==\", \"time\": 0, \"size\": 80151, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ff1672c07b4b44fc305361d472f8b50fb267eca69de0c97285f361baca56",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/cc"
     },
     {
         "type": "inline",
-        "contents": "a8fb9512413742ffd2d44dbf91716f68f490304d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.50.tgz\", \"integrity\": \"sha512-5e76wQiQVeL1ICOZVUg4LSOVYg9jyhGCin+icYozhsUzM+fHE7kddi1bdiE0jwVqTfkjba3jUFbEkoC9WkdvyA==\", \"time\": 0, \"size\": 5957, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.50.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "34fd0e729aa48ec200512629bb7078b45ba81e891db070d148eafe229563",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/fe"
+        "contents": "9fd789ef7f99c2232e1b4cb0d90a523af5b92359\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz\", \"integrity\": \"sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==\", \"time\": 0, \"size\": 18900, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "27c65b08946ea111d63902df1ea2f7dced1873d1cd9c85848bf63bbd2baf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/9e"
+    },
+    {
+        "type": "inline",
+        "contents": "a02f72a26f794ed8e60bd91c5c127dfb10d80431\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globals/-/globals-15.15.0.tgz\", \"integrity\": \"sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==\", \"time\": 0, \"size\": 25441, \"metadata\": {\"url\": \"https://registry.npmjs.org/globals/-/globals-15.15.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "274804434fd487e0568e483661484af7b9d77750dd90aaff25f6a6cfef65",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/5b"
+    },
+    {
+        "type": "inline",
+        "contents": "a0b1a8605deaf6d1e7ce3e8e780596768c2a44cc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz\", \"integrity\": \"sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==\", \"time\": 0, \"size\": 4181608, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "eb0a6fc2a9078e3d0e52050a79c9aeade40650f02b0fe8b74c9850a0b8f6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/a4"
+    },
+    {
+        "type": "inline",
+        "contents": "a0be89300eb8ed18b2befa067c479eba68163fb9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"integrity\": \"sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==\", \"time\": 0, \"size\": 2206, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7d95a8e3571758f8b5d095a21909a8f6cdfe7fd2349f7f72b2801eef079",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/d5"
+    },
+    {
+        "type": "inline",
+        "contents": "a14ac3a7e79dcc0c3be1c1cb13ac91e3a523da05\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz\", \"integrity\": \"sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==\", \"time\": 0, \"size\": 2149, \"metadata\": {\"url\": \"https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "96f9fcc533e049869e9b00ffe42e3b0fa381051c8997cdfeb7bc0d0d843f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/a8"
+    },
+    {
+        "type": "inline",
+        "contents": "a2c6730db5276a4f496908a3aaeb4791116d3cba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz\", \"integrity\": \"sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==\", \"time\": 0, \"size\": 8079, \"metadata\": {\"url\": \"https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "519103a79db19d6d95ed157de08cbd809b32139119e6d02adaf2deeb017a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5f/40"
+    },
+    {
+        "type": "inline",
+        "contents": "a2ca864cfaea25699df81e129095316ae07f8956\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz\", \"integrity\": \"sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==\", \"time\": 0, \"size\": 11377, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "211d19f87bd3d47c875f803133fab6d0d895cb6f8284f41b2b3fee63f93d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/ec"
+    },
+    {
+        "type": "inline",
+        "contents": "a31c95b52d4130ded9d6c981ebc3df1dea077599\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz\", \"integrity\": \"sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==\", \"time\": 0, \"size\": 7131, \"metadata\": {\"url\": \"https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "942ca9681194e0ee4cdb47fed52f002f217afb74aa67da1b9a73dadcba2c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/a1"
+    },
+    {
+        "type": "inline",
+        "contents": "a3585259fd86f86a52d7151fa4870fc587eea316\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz\", \"integrity\": \"sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==\", \"time\": 0, \"size\": 16881, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5f0ec4fcb95c4ce76097ab32efc32bb95ccc6d0b8640dbdd47e85c870beb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "a3a5f6c1106f1d5a3e6fa1b5dc174df5bb32a334\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/espree/-/espree-10.4.0.tgz\", \"integrity\": \"sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==\", \"time\": 0, \"size\": 17313, \"metadata\": {\"url\": \"https://registry.npmjs.org/espree/-/espree-10.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "117b08bed4e0eab131e59b5437b3f282263ed761bd544830a76bfb3c37d6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/e9"
+    },
+    {
+        "type": "inline",
+        "contents": "a481f9f5caade7d1e25e2005bd586788297ee48b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz\", \"integrity\": \"sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==\", \"time\": 0, \"size\": 2258, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8af21194b7c666dcff699b874730170edc9a2670a4d17bf4186649ee9fa7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/96"
+    },
+    {
+        "type": "inline",
+        "contents": "a4d30eff6cd379ad7e36f2a905c06ed6eb47b728\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz\", \"integrity\": \"sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==\", \"time\": 0, \"size\": 8576, \"metadata\": {\"url\": \"https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "da2bbce756c0c5feab9837df723b4bd48ee7849efc390afe3c1f9e8207d5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/4b"
+    },
+    {
+        "type": "inline",
+        "contents": "a5353375281b976a160d023dd696db9df8c88458\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz\", \"integrity\": \"sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==\", \"time\": 0, \"size\": 39652, \"metadata\": {\"url\": \"https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "79104b96f0483e5d0659d111db62f8ad9597fe9a247960c81c25b50913a3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/e4"
+    },
+    {
+        "type": "inline",
+        "contents": "a54a1a257eaf9ae60cd0a630818e8731cdfb44ab\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz\", \"integrity\": \"sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==\", \"time\": 0, \"size\": 565295, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8f3d655c77c218dc3c4b02b0676405597df09dc966d5d7c3d73c1d095642",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/4c"
+    },
+    {
+        "type": "inline",
+        "contents": "a5c335aa0f624c7c9a54ba7e3d7fccbe87bc9de0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz\", \"integrity\": \"sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==\", \"time\": 0, \"size\": 2954, \"metadata\": {\"url\": \"https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f99ab9b86ec4a9a5033a4b41f687abf6110c7960ef61b601ec5567a38010",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/72"
+    },
+    {
+        "type": "inline",
+        "contents": "a5dd2592e5100b55d5779cae762039371f5f0d32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz\", \"integrity\": \"sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==\", \"time\": 0, \"size\": 4735457, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a44e5a0cc6cf4b1e18c2a1a922164990ef31c8eb4435d53e495f717e5b17",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/09"
+    },
+    {
+        "type": "inline",
+        "contents": "a618cd4584f109de835b241c86ce2c370220a607\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz\", \"integrity\": \"sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==\", \"time\": 0, \"size\": 7090, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1d26498054c07107bca5dec3e4c244be0003d52ac2eebc92797ebafba65f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c5/39"
+    },
+    {
+        "type": "inline",
+        "contents": "a66f4dcfa2fd76b001d698b87fb816a8f716b03c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz\", \"integrity\": \"sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==\", \"time\": 0, \"size\": 9014, \"metadata\": {\"url\": \"https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8cbac938183921305c24edc0bd4a55f3550c1af92d5335d61ffb56cec2b0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/50"
+    },
+    {
+        "type": "inline",
+        "contents": "a855fb0327e6b145dcb5d18c13d77dc4bf698711\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz\", \"integrity\": \"sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==\", \"time\": 0, \"size\": 4872, \"metadata\": {\"url\": \"https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "977c502f376e32fd006c97ac1f37f5d6f54a5d6e5bff96e62baacdf7d3b1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8e/8e"
+    },
+    {
+        "type": "inline",
+        "contents": "a858e00e93c3d86e08b1774019d205a1e397e3c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz\", \"integrity\": \"sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==\", \"time\": 0, \"size\": 4441, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3df3c17d68eab8fdc9aaeb34a5bde764c0f400141c1262354039c5b7f67d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/3d"
+    },
+    {
+        "type": "inline",
+        "contents": "a8c4da59d6665dba413b13d7890e0f5590df2a30\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz\", \"integrity\": \"sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==\", \"time\": 0, \"size\": 74891, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6de6a26defefd18956c322b0286b3dc92d798e39a44483c0cfe290e236e3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/ad"
+    },
+    {
+        "type": "inline",
+        "contents": "a8cbed5095ad2356a896a4b533b74508a16d3566\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-pnpm/-/eslint-plugin-pnpm-1.4.3.tgz\", \"integrity\": \"sha512-wdWrkWN5mxRgEADkQvxwv0xA+0++/hYDD5OyXTL6UqPLUPdcCFQJO61NO7IKhEqb3GclWs02OoFs1METN+a3zQ==\", \"time\": 0, \"size\": 9667, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-pnpm/-/eslint-plugin-pnpm-1.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f95d57111a7bf4d37390456d74fda54f4b2032f57bc8880bd827722ca85c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/16"
+    },
+    {
+        "type": "inline",
+        "contents": "a91cb6208b484067ccb329f53f12341cbbf5d5f9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz\", \"integrity\": \"sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==\", \"time\": 0, \"size\": 4707419, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "db7ab03e5e33b791373d3f64844d6f5721a47b9956c30c363de27b23882e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b5/ea"
+    },
+    {
+        "type": "inline",
+        "contents": "aa28ffd220acadd35f1a838551fd3de7c695dc0a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz\", \"integrity\": \"sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==\", \"time\": 0, \"size\": 8109, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "17d5aa3783c612239557f251b2be4fdcb43aec68db7405d1d6b7a9377c5d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/8d"
     },
     {
         "type": "inline",
@@ -1325,33 +4348,111 @@
     },
     {
         "type": "inline",
-        "contents": "aae0fe706f90706626c8833c0abcf290f5cd0757\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz\", \"integrity\": \"sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==\", \"time\": 0, \"size\": 4476447, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "05c3f386c9f3d6d54791e74a7fefeb871cc6b7a7d1d71eadcdd581939e5e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/c6"
+        "contents": "ab1535e11418f78fd1b1480ea7599f2c8d4f64a4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz\", \"integrity\": \"sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==\", \"time\": 0, \"size\": 4349604, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ebf71bd2df9b9022fffefa2344dfcefee5b76793b3bf361a6a1ca21251d0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/f0"
     },
     {
         "type": "inline",
-        "contents": "acfa068b7841eb093d8878af7195cf9db5519b19\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-OsqEs+ZHu+LN4mVLHOJxiVL876bYtmm4t9IrqJiYgixgWk4Kd3BJIyuTzN0mFKfSMHUeISiHlzgcMPeEyQVGkg==\", \"time\": 0, \"size\": 193520, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "c18a40318456322687707af265f340b51486074ca654a5e1ed12ef06167c",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/e4"
+        "contents": "ac2e1a101e21bdd73d147d9d1f7d11f94bcc00b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz\", \"integrity\": \"sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==\", \"time\": 0, \"size\": 3503, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "24d19ec40f20e600a1d29c92d6c7264655db3184b377b19913e18eececce",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/aa"
     },
     {
         "type": "inline",
-        "contents": "b0d479f8e426170b73f1e75e70debd5abf5f7c9b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-MmKeoLnKu1d9j6r19K8B+prJnIZ7u+zQ+zGQ3YHXGnr41rzE3eqQLovlkvoZnRoxDGPA4ps0pGiwXy6YE3lJyg==\", \"time\": 0, \"size\": 7777993, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "ba73a9f72f015f4eaedf8e091ba70e7e070091e4f1825e8432c574737244",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/b5"
+        "contents": "ad4afe5e3902407d570d4593e811d988402af70d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz\", \"integrity\": \"sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==\", \"time\": 0, \"size\": 2170, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "61ee147c6fed8d41b791b3e1eef44fd441678975a2a8877c156732812496",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/2a"
     },
     {
         "type": "inline",
-        "contents": "b2eecb3e07acec445265e203704415ab7ee84e27\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz\", \"integrity\": \"sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==\", \"time\": 0, \"size\": 4513742, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "640d3b5892f5b0a59a2a1bd334ff0f480a5220e2e68e54bd95cd42a38d31",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/94"
+        "contents": "ad6598e67b468ec67075be63a19667facbef49da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.26.tgz\", \"integrity\": \"sha512-JJw0Tt/kSFsIRmgTQF4JSt81AUSI1aEye5Zl65EeZ8H35JHnTvFGmpDOBn5iOxd48fyGE+ZvZBp5FcgAy/1Qhw==\", \"time\": 0, \"size\": 4273, \"metadata\": {\"url\": \"https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.26.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "efb2c740b041425a18fac69190e38903dd5bcc61a91ee5e6d8e06569c386",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/13"
     },
     {
         "type": "inline",
-        "contents": "b5f271de3cae5de61f8e9302dd7f3853e642dfda\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-D0Ay58EI7MPjTit+oCfjAFoI9o9/wc+nW9GngLpDPibfov5IQWxZ/QSmjx/o1MAZb7Gv5wTLGOboVL8OBfAdsA==\", \"time\": 0, \"size\": 169916, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "507596bdb0e1aabbf99cf9071a8a4860b4f132f14e8cf4185c965eb81a80",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/17"
+        "contents": "aed264ff456d1434b6d03d6c6bd9c5f785e9acd4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz\", \"integrity\": \"sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==\", \"time\": 0, \"size\": 1621, \"metadata\": {\"url\": \"https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fc46f5c221a0049b2c5ce36c0d6d7514868921f50b2b985f87959a60a217",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/08"
+    },
+    {
+        "type": "inline",
+        "contents": "af94b9a500ee4631018c9a104b5d108b60d4aea7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz\", \"integrity\": \"sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==\", \"time\": 0, \"size\": 4255, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2ac6234e08578459cc70534addafba44ecd5267c7510db659945c34b184d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/ea"
+    },
+    {
+        "type": "inline",
+        "contents": "b0ccae6399f1609c1923d9153597385715356091\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz\", \"integrity\": \"sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==\", \"time\": 0, \"size\": 4620950, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4a2eb7186fa21c076d48c3d884c859397ead254ee08679a3e2b609377244",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/6a"
+    },
+    {
+        "type": "inline",
+        "contents": "b172e2cd76fb97e0f9f5aa666ff6d4d80bfaa8b1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/levn/-/levn-0.4.1.tgz\", \"integrity\": \"sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==\", \"time\": 0, \"size\": 7465, \"metadata\": {\"url\": \"https://registry.npmjs.org/levn/-/levn-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0bd207e4befdc1899d2abf0d3271f34fd6bd81eaaa9e7f4b005488802bb0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/de"
+    },
+    {
+        "type": "inline",
+        "contents": "b2c5ac3e4c395be530fdabcf64d44e02df979f1d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.10.1.tgz\", \"integrity\": \"sha512-9mjy3frhioGIVGcwamlVlUyJ9x+WHw/TXiz9R4YOlmsIuBN43r9Dp8HZ35SF9EKjHrn3BUZj04CF+YqZ2oJ+7w==\", \"time\": 0, \"size\": 26922, \"metadata\": {\"url\": \"https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.10.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d2717241ae4710e5b0f9c8b3eba68b02da46a7281eb60f7f70b11b0b745e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/4e"
+    },
+    {
+        "type": "inline",
+        "contents": "b4999f5d2c109cb8535f12675d17611e09847fd9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.6.1.tgz\", \"integrity\": \"sha512-JCs+MqoXfXrRPGbGmho/zGS/jMcn3ieKl/A8YImqib76C8kjgZwq5uUFzc30lJkMvcchuRn6/v8IApLxli3Jyw==\", \"time\": 0, \"size\": 133197, \"metadata\": {\"url\": \"https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "21b69bf51988acf750bdc093b16831bde615ca0585bcbac06425d6f5f4fc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/90"
+    },
+    {
+        "type": "inline",
+        "contents": "b5d16bf14c5b16afbf2e4820d2bfef925dfeb8bc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz\", \"integrity\": \"sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==\", \"time\": 0, \"size\": 3449, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c7d3cc971492220b7cec031eec035df5e60b61a4319081d0cc87870409b3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/a4"
+    },
+    {
+        "type": "inline",
+        "contents": "b5f5dd347ce0adacc47cc4ec7451475b64131585\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz\", \"integrity\": \"sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==\", \"time\": 0, \"size\": 3783, \"metadata\": {\"url\": \"https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cabf73abe8a138732bad05ef4e056eb7b8b71ad2b2447ab1e81ae2cb5eeb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/e0"
+    },
+    {
+        "type": "inline",
+        "contents": "b5fd274e133de99efb0b383ffd305a14753b501f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz\", \"integrity\": \"sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==\", \"time\": 0, \"size\": 3717, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "036ff49d1ad68738b74d1cd3536347032c5653aa8eb6c4fb8113f0bb041a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/78/7c"
+    },
+    {
+        "type": "inline",
+        "contents": "b6b41c41bb35148054851d2695cf088d06f1f93f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz\", \"integrity\": \"sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==\", \"time\": 0, \"size\": 73417, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7fc8fb088ff37e4ff427d1fec06dd168abfd2fcda2b0ea1489ca5010fb91",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/7d"
+    },
+    {
+        "type": "inline",
+        "contents": "b7b2c53e78216e19ccd892db974a1382354d600e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz\", \"integrity\": \"sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==\", \"time\": 0, \"size\": 4483, \"metadata\": {\"url\": \"https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8e01e6bce59ac02f0d20fc97382749190cb73f6006f9526fc7fb1ec79dd4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/26"
+    },
+    {
+        "type": "inline",
+        "contents": "b80b8ae25a2a10c0c5b6691530dbf72e2c5f7a6b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"integrity\": \"sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==\", \"time\": 0, \"size\": 5849, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c2ea22c4bf9c5ddcd0333850e543442de3364478847c7ebc382b1ff3a70d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8b/ee"
+    },
+    {
+        "type": "inline",
+        "contents": "b8101b2dd09f7bd918b716c8cc0952465caf247a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz\", \"integrity\": \"sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==\", \"time\": 0, \"size\": 71689, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "181bae773c4424985d39b274181a10179be7c6a7300aab69acb2d1f874b8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f1/8a"
+    },
+    {
+        "type": "inline",
+        "contents": "b83094f81a4ce0fb77a6ebad1b7966ee48cf465a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz\", \"integrity\": \"sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==\", \"time\": 0, \"size\": 851, \"metadata\": {\"url\": \"https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7f5c2553e6c049b34101f73a757b48a2764e6eeaec39265c917bf2df693",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cb/60"
     },
     {
         "type": "inline",
@@ -1361,9 +4462,75 @@
     },
     {
         "type": "inline",
-        "contents": "bf7037bc33af2ac216defaf02eb826020c444cc8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-ENLmSQCWqSA/+YN45V2FqTIemg7QspaiTjlm327eUAMeOLdqmSOVVyrQexJGNTQ5M8sDYCgVAig2Kk01Ggmqaw==\", \"time\": 0, \"size\": 8104707, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "22b545df4f2fe50b64f31b7918b5bf3a84e3fa2e6e6c1266a3c6a7b434e3",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/77"
+        "contents": "b9b617e9648f1f7a6db7f5758856dcb3f1d01086\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/format/-/format-0.2.2.tgz\", \"integrity\": \"sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==\", \"time\": 0, \"size\": 3259, \"metadata\": {\"url\": \"https://registry.npmjs.org/format/-/format-0.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "850fafd642930ab1a1bdfd4e42442312b46b4c517c1fafb4cb1a63654e8a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/10"
+    },
+    {
+        "type": "inline",
+        "contents": "ba41a88cf3bed6db1eb8cc60e3a120005b733423\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz\", \"integrity\": \"sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==\", \"time\": 0, \"size\": 4249698, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b63b623771d94d1296340072eea78ee400f8c819d117cde9578894ba3c01",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/94/e8"
+    },
+    {
+        "type": "inline",
+        "contents": "bab1d55b725ccdbe3024215d16697c79429ab431\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.10.0.tgz\", \"integrity\": \"sha512-+LexoTRyYui5iOhJGn13N9ZazL23nAHGkXsa1p/C8yeq79WRfLBag6ZZ0FQG2aRoc9yfo59JT9EYCQonOkHKkQ==\", \"time\": 0, \"size\": 189801, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.10.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b306e7b65ab110cdb8e575c61225cb879ba2fb2e3e123968238167bc2e7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "baeecf7e0d9555175f221b5b360ae4894e31986c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz\", \"integrity\": \"sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==\", \"time\": 0, \"size\": 15047, \"metadata\": {\"url\": \"https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6eb9d82a94d58e578319b63f3658cc1de1098499a35c6a26dfa7c54e3952",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/37"
+    },
+    {
+        "type": "inline",
+        "contents": "bb40ce5afc48bdd997ae9e98c8753481a7600fb3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz\", \"integrity\": \"sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==\", \"time\": 0, \"size\": 6359, \"metadata\": {\"url\": \"https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "001b0f34f310083bbe9f021b27b50849321d190c71f1448e061495d03586",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/3c"
+    },
+    {
+        "type": "inline",
+        "contents": "bb900fe0e77db58ae59750d2c0af1db2eaccbc42\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz\", \"integrity\": \"sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==\", \"time\": 0, \"size\": 69071, \"metadata\": {\"url\": \"https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7a809d39c26591aa96dbad9b2bc3c77536b751585a476a20a8f1942a4783",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/a6"
+    },
+    {
+        "type": "inline",
+        "contents": "bc071c15d122e841b8ec82fc0e4fb1a870881ff8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz\", \"integrity\": \"sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==\", \"time\": 0, \"size\": 6318, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "216edd7104928342f4e596f226b589b3733c83a5c056ece5738890de4460",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/20"
+    },
+    {
+        "type": "inline",
+        "contents": "bd2a610aa5f499723bbf0e1a3d74cd84fa94a7ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz\", \"integrity\": \"sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==\", \"time\": 0, \"size\": 2663, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "76c21652f2169a69eaaea1063b83090d4a616b9b952147bafbb6e4588813",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/6b"
+    },
+    {
+        "type": "inline",
+        "contents": "bdf94d948b168388e33bd2e1d571bad282a23440\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz\", \"integrity\": \"sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==\", \"time\": 0, \"size\": 9408, \"metadata\": {\"url\": \"https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cc8592ab15d662d89edc5604d9f6347e26fbca3465f5f245b65eefb11d93",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2e/c8"
+    },
+    {
+        "type": "inline",
+        "contents": "be6425d3da158b06378570ecd58792f5c211bf0f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz\", \"integrity\": \"sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==\", \"time\": 0, \"size\": 7094, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d1d3f279be9faa54eff0220b571514ddb43fca380feb57997c77655aeca6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/2c"
+    },
+    {
+        "type": "inline",
+        "contents": "bea4197bc152523f708d0591bc66bbdc64d16ec9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz\", \"integrity\": \"sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==\", \"time\": 0, \"size\": 4186443, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aeca147f1f7c2837dd240211ba3e32af20348e98853b2c0c1ac6fe70ca81",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/a9"
+    },
+    {
+        "type": "inline",
+        "contents": "bf36c5feefa9827b2423840ecef90ba9e56ba160\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz\", \"integrity\": \"sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==\", \"time\": 0, \"size\": 5007, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aff70870affa720188dbb582a4adbc27e66b1a6eee7b4920a047d94247c7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/a8"
     },
     {
         "type": "inline",
@@ -1373,9 +4540,99 @@
     },
     {
         "type": "inline",
-        "contents": "c227d9dac669ef2804bf47371c289f09aae6c013\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz\", \"integrity\": \"sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==\", \"time\": 0, \"size\": 4205678, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "1980e3606fc9c385577e0413b657e6975019731caa4201b43fa91b789e61",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/1a"
+        "contents": "bff5329721b1705fcc248a385a670c4ba1b3dfba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-9Tmp7bBvKqyDkMcL4e089pH3RsjD3SUungjmqWtyhNOxoQMh0fSmINTyYV8KXtE+JkxYMPWvnEt+/mfpVCkk8w==\", \"time\": 0, \"size\": 8540042, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5df7f640ba44f7076ef8b7bfd88976e3e5b5837edf7be2ed665296966763",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/66"
+    },
+    {
+        "type": "inline",
+        "contents": "c08c5428756a52a583d5dbf414c1c7059639b03e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz\", \"integrity\": \"sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==\", \"time\": 0, \"size\": 7095, \"metadata\": {\"url\": \"https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ec243b95b1076bc9f305bcd51792083202c873f3e8f260f921f58212ff12",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/b0"
+    },
+    {
+        "type": "inline",
+        "contents": "c0f9f449a33edb2a303d7529b0393d365e57a109\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz\", \"integrity\": \"sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==\", \"time\": 0, \"size\": 3833, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e29c2df4db20f8ce1887ff2ddf54054107a01359b979bffbd87131329856",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/43"
+    },
+    {
+        "type": "inline",
+        "contents": "c28fe4791f43624b89128496ffd323886f7be2e9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz\", \"integrity\": \"sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==\", \"time\": 0, \"size\": 331210, \"metadata\": {\"url\": \"https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "54f5ed90033df714583fb4b7949a62e83f2e1f06bf84cd87d615b4a43405",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/1d"
+    },
+    {
+        "type": "inline",
+        "contents": "c2e62843ebc89d40fc8a416005962e7fa8c3ac4e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.3.tgz\", \"integrity\": \"sha512-TlGPkLFLVOY3T7fZrwdvKpjprR3s4fxRln0ORDo1VQ7HHyxJwTlrjKU3kpVWTlaAjIEuCTokmjkZnr8Tpc925w==\", \"time\": 0, \"size\": 22479, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bb0f8a24135f11e939b339fe0300c9868a3d838ffc6024b73fcf908fa115",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/68/26"
+    },
+    {
+        "type": "inline",
+        "contents": "c36a4344f60f78677eb2a507571ca18431f911b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz\", \"integrity\": \"sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==\", \"time\": 0, \"size\": 1503, \"metadata\": {\"url\": \"https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b652af7d985d655c33bbc6261689ea2f5a550b485dde76ad3aefbe2591eb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/af"
+    },
+    {
+        "type": "inline",
+        "contents": "c375a623b22500e0b5ad9180961e5bc8a1742f6b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz\", \"integrity\": \"sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==\", \"time\": 0, \"size\": 10038, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1394bfe3119ef9620ccb5d4eb6c4001ab70c64efb55f558a35ad46138686",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/96"
+    },
+    {
+        "type": "inline",
+        "contents": "c3dd89f9acdb31ccea572280a9a9d4503554474c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz\", \"integrity\": \"sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==\", \"time\": 0, \"size\": 1578, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "baddd71f459a50b3c710a007fa7d59fa62febef98033b7331374bf02db64",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/fc"
+    },
+    {
+        "type": "inline",
+        "contents": "c3efdd5bdec8983bbe42ab1253cd644b63bea067\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz\", \"integrity\": \"sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==\", \"time\": 0, \"size\": 4477553, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b47d2ed18ab36d6df629e07055746c45c12b93dd40968e66cec89cae945",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f7/1c"
+    },
+    {
+        "type": "inline",
+        "contents": "c4d079f82d7b1c018850a0e66ed184a4a591eefa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz\", \"integrity\": \"sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==\", \"time\": 0, \"size\": 3199, \"metadata\": {\"url\": \"https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6eebd661baa0674ab0637645fd7c1ab73a710e35906590aeae6913af9f2b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/dd"
+    },
+    {
+        "type": "inline",
+        "contents": "c649e494deec3d6cd4f64297b198e2c1dfd9c7ea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz\", \"integrity\": \"sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==\", \"time\": 0, \"size\": 13589, \"metadata\": {\"url\": \"https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ac136630261add7b387011766c8c618336b3b82f755809264088bbb23de3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/55"
+    },
+    {
+        "type": "inline",
+        "contents": "c7a1c5b38eded89b639c419f58eeff2632404cda\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz\", \"integrity\": \"sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==\", \"time\": 0, \"size\": 4408, \"metadata\": {\"url\": \"https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "360a5e6d0716b47be79dbc22d7a081b7bce25b0d07265010cd8411c88711",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/71"
+    },
+    {
+        "type": "inline",
+        "contents": "c7c79573eced543bfdb6d056f08780c237ceab56\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz\", \"integrity\": \"sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==\", \"time\": 0, \"size\": 2197, \"metadata\": {\"url\": \"https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8fbdcf23dee6c4dbd86aa3e1cb512049c26387ea573a21867de70b9a63fd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/f2"
+    },
+    {
+        "type": "inline",
+        "contents": "c80ebdb8ff61a0e7fbc92a78fa941e75b3f5e0c4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz\", \"integrity\": \"sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==\", \"time\": 0, \"size\": 80588, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0d4e5c8fa2a31bb9859f015242a4e6e7cc16a63d67350ffcf844651f9363",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ad/94"
+    },
+    {
+        "type": "inline",
+        "contents": "c810d6647f8c37d1119cfb52fea7bf63e9ac6aeb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz\", \"integrity\": \"sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==\", \"time\": 0, \"size\": 5192, \"metadata\": {\"url\": \"https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "37b74b464ff21c841ecd6ddbd4329f6f04a7cc17abe4b766f67aec367c09",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/4f"
+    },
+    {
+        "type": "inline",
+        "contents": "c85412fcb89a8343eacae968a6514fe67818ee63\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz\", \"integrity\": \"sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==\", \"time\": 0, \"size\": 3151, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7d3c580b65869fc4f55b962ca87f8ed801eeb7d0a568c2b65f39ea2df787",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f1/17"
     },
     {
         "type": "inline",
@@ -1385,15 +4642,93 @@
     },
     {
         "type": "inline",
+        "contents": "c87ff8d709eb5c57a52f6004a843c62fa77f9ae1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz\", \"integrity\": \"sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==\", \"time\": 0, \"size\": 73509, \"metadata\": {\"url\": \"https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3157c5490ffcc2b806d297595bf2452995c41918b3abdf6d16f54ab34a78",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4d/bd"
+    },
+    {
+        "type": "inline",
+        "contents": "c8a5706006c7272b34109041e53fbf4865386e30\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"integrity\": \"sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==\", \"time\": 0, \"size\": 11577, \"metadata\": {\"url\": \"https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "375aec77f76404d91225e72006a0105b2a6ec04bb02cfa365ebcd4a0232b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/7c"
+    },
+    {
+        "type": "inline",
         "contents": "c8e2f20fac60a6a5e43f7d1c64db82d267cf5fac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz\", \"integrity\": \"sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==\", \"time\": 0, \"size\": 5484, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "5562a02de372338cd5b15db91389e2cb1f9f6fb701533f5603888d15371b",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/e0"
     },
     {
         "type": "inline",
-        "contents": "ce64c11d1ca6ee9c2d5960ac1ec4614824fdf5c0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz\", \"integrity\": \"sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==\", \"time\": 0, \"size\": 3638266, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0e905072b4ced99a8b5de43392aea63d2f6337f7a49a530353534c029199",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/02"
+        "contents": "c92d43871f1a094c16e908b57b25924269a99301\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz\", \"integrity\": \"sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==\", \"time\": 0, \"size\": 7145, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d7336a88a91d19e6e84f61c4bf61668ba80fab5ac3565ae3351548708a18",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/4a"
+    },
+    {
+        "type": "inline",
+        "contents": "cadc8fab52a7f02f48530089da4fabba9e3f4066\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz\", \"integrity\": \"sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==\", \"time\": 0, \"size\": 4392973, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "76260f00ac4e2da2f87589e69a600f2fcebdddb275ddcb558cff44d3247b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "caf2cef9e57fd1035961a49a5c778d77a56cc57e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz\", \"integrity\": \"sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==\", \"time\": 0, \"size\": 2618, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ce47a91aa4c10cda303c5b693122434fcebd897428fb2d4b7b305796453a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/4d"
+    },
+    {
+        "type": "inline",
+        "contents": "cbaf03e7fc714173118487c9e12c3cebe985d9c9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz\", \"integrity\": \"sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==\", \"time\": 0, \"size\": 312256, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1d241ec066490362012de8636cba341016863f56f1559529f809f0a5c04b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/0a"
+    },
+    {
+        "type": "inline",
+        "contents": "cd60deef05cb4e45c641d6ff08b0b0467f078252\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz\", \"integrity\": \"sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==\", \"time\": 0, \"size\": 4615118, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5e5ddf212a86945b74eed37ae836b39b48f4495833f02b48b61d4044bfc3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/20"
+    },
+    {
+        "type": "inline",
+        "contents": "cda515208cceaab2c621efb28d7570d13dbcd4a6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz\", \"integrity\": \"sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==\", \"time\": 0, \"size\": 96471, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "741347bd7ef970d697d9f40bfef4975857c6fb7a05b9daea18a30c3aa9af",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/34"
+    },
+    {
+        "type": "inline",
+        "contents": "cdad0fedb64e50fa7d9369f41d60f0100eefd8f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz\", \"integrity\": \"sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==\", \"time\": 0, \"size\": 1741, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1852e5539d639f64b50d12669fbae8a41998b190c48ede99d0d60e181d55",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/c2"
+    },
+    {
+        "type": "inline",
+        "contents": "cdd286d5c1b7801fc1b36adf8401298d1d23689e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz\", \"integrity\": \"sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==\", \"time\": 0, \"size\": 1964, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "242694f95c0450af50bdbf24aa1b40f4f6130be06c8781090a39c01c8cc4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/2a"
+    },
+    {
+        "type": "inline",
+        "contents": "cf0857bde2e11d89f107c4f8edd0fb2d86afd568\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz\", \"integrity\": \"sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==\", \"time\": 0, \"size\": 4353, \"metadata\": {\"url\": \"https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f2b394cd0eac5489f1b51a8fbc6cbd5f3627722906c589f63ff46738a3fd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/86"
+    },
+    {
+        "type": "inline",
+        "contents": "cf554ee8dd9468e71cacf2bd08904cd51e98f8da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-s27uU7tpCWSjHBnxyVXHt3rMrQdJq5MHNv3BzsewCIroIw3DJFjMH1dzCPPMUFxnh1r52Nf9IJ/eWp6LDoyGcw==\", \"time\": 0, \"size\": 8191345, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b3cb01fa532c027dc0a5e73b390f2838b247adcdd8e4891905ec8328158",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/f7"
+    },
+    {
+        "type": "inline",
+        "contents": "cfbbed1ad0de471de93f5021de6c87f46fb591d9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz\", \"integrity\": \"sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==\", \"time\": 0, \"size\": 5223, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7b0ebdc21c4cce43b7684759e7f065db7f787a33d320bd5fd161181914f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/3c"
+    },
+    {
+        "type": "inline",
+        "contents": "cfd9cafd22770df22314167fdefd2b76c2333767\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz\", \"integrity\": \"sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==\", \"time\": 0, \"size\": 3400, \"metadata\": {\"url\": \"https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "99a7db3a3209b5de2c760de391f5d6844b67a72311c9da9da01366aaa562",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/46"
     },
     {
         "type": "inline",
@@ -1403,9 +4738,21 @@
     },
     {
         "type": "inline",
+        "contents": "d2832da221bb092338f25fd5cb7b00d732a10c2d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz\", \"integrity\": \"sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==\", \"time\": 0, \"size\": 4589, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cf39b6135a769e343477b672ceedea780ab90fdf1dc3e83d17dbab0cf003",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/21"
+    },
+    {
+        "type": "inline",
         "contents": "d31c9160378263d3bc01ee81e386c673303cf2d8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz\", \"integrity\": \"sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==\", \"time\": 0, \"size\": 138324, \"metadata\": {\"url\": \"https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "97d2c6e5c772f993e1a5b5fdeae5e52c835ac89d689ba43dbe025d54d880",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/e8"
+    },
+    {
+        "type": "inline",
+        "contents": "d3c14a7a306f205259120e1a1431cefb8e3b45df\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-2.10.0.tgz\", \"integrity\": \"sha512-ovzQT8ESVn5oOe5a7gIDPD5v9bCSjIFJu57sVPDqgPRXicQzOnYfFN21WoQBQF18vrhT5o7UMKFwJQVVjyJ0ng==\", \"time\": 0, \"size\": 144576, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-2.10.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2d92b4f1dfcdf1e989ddffaee507a6bb5a224ac85049028c88ffdd62d3f5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/26"
     },
     {
         "type": "inline",
@@ -1415,15 +4762,39 @@
     },
     {
         "type": "inline",
-        "contents": "d816a09e65386a4e315fe6b5d3dd694b325302fb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-yJqnWAAJFS+EzFM/TRgonreAiO/IdLVLvlOxOzY0mEGEggfnuizzgSRQwR00JtgA9JC4gQkwKSnNwkWv4oHH2Q==\", \"time\": 0, \"size\": 146069, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "5c6e63435071ada1df66f623f51d3e583e48877ea2fe078ca1243ff31792",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/fa"
+        "contents": "d6cd79d182a6db834df4e9ca443e37abac96491d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz\", \"integrity\": \"sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==\", \"time\": 0, \"size\": 37469, \"metadata\": {\"url\": \"https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c518a11ef807da59cc69e4fa3080a330ab78ec7f90058cea1e02e6e3bfbe",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/47"
     },
     {
         "type": "inline",
-        "contents": "d9f1dc40ba78efb04e45ec35c3a04655438eebd7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.5.tgz\", \"integrity\": \"sha512-G4VsXTqdHy+W1jdksU3S6twwt3lM/DNbN2CMuIcJt7I1zwj97n+iRpgv77k3QCieDQ7xNXrfG3eMt/XY4epVSA==\", \"time\": 0, \"size\": 571711, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.6.0-alpha.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "215cef795735431d7fade1881d18ca5079cf8a07b9526039aaa15f333167",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/2d"
+        "contents": "d9ccbe31d088493dc49dcb575b713161abf96f2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz\", \"integrity\": \"sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==\", \"time\": 0, \"size\": 320554, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "62c3b81fb7c36d05e68083ed112261d508fa3cd0b6a15b38d0e2b8f68d97",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/94/ee"
+    },
+    {
+        "type": "inline",
+        "contents": "d9d308d9a488ff2be7ce561eec05edae6e5aa7ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which/-/which-2.0.2.tgz\", \"integrity\": \"sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==\", \"time\": 0, \"size\": 4496, \"metadata\": {\"url\": \"https://registry.npmjs.org/which/-/which-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5a271b1898a503a6f8a6b2361235fd7539e9ae1aa5622d3e78124d1a0c34",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/9d"
+    },
+    {
+        "type": "inline",
+        "contents": "da2879c73552cf2aa6dca9d6bea11a971f4fa8b8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz\", \"integrity\": \"sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==\", \"time\": 0, \"size\": 2566, \"metadata\": {\"url\": \"https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "453e33186da98d920c645a62338a6e2a17b4e5c9a65b1b782bea3eecd62d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/82"
+    },
+    {
+        "type": "inline",
+        "contents": "dc388df89c9a5c41d491ba04ab8a174115b0fbe6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz\", \"integrity\": \"sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==\", \"time\": 0, \"size\": 133427, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "391b969b002ebff24cf76c499a0c16725eaa59904f971377de27fe01bbca",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/97"
+    },
+    {
+        "type": "inline",
+        "contents": "dea63000c46bd19ecf25d2bbae2f7381736e8ead\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz\", \"integrity\": \"sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==\", \"time\": 0, \"size\": 9837, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "516d3fb789a329a09f0835fd3d6aaa34f229fc299e51f7aca709f10dfce6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bc/07"
     },
     {
         "type": "inline",
@@ -1433,9 +4804,27 @@
     },
     {
         "type": "inline",
-        "contents": "df46d4302548b8c35b6b914ad2f8e508b514b81b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz\", \"integrity\": \"sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==\", \"time\": 0, \"size\": 4733987, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "502e82ac27985a62ca67de907ecb0b0014f68a18812a9f04565551a84788",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e5/20"
+        "contents": "deed4f895798ef648b089462a8944ab70696d882\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz\", \"integrity\": \"sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==\", \"time\": 0, \"size\": 4216, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cf95d6687acbe3f0d6c1517cf85ecc1798b5cfdbe0543814c7faf418322f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/45"
+    },
+    {
+        "type": "inline",
+        "contents": "df3c75ad3d29fbb10c0bf77d7c7ab13e5a45f7f3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz\", \"integrity\": \"sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==\", \"time\": 0, \"size\": 19275, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "50ab90e95fc5a156f59856f48ae4b47d9db216cd36a5fcbfa087c3b018fb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b5/d5"
+    },
+    {
+        "type": "inline",
+        "contents": "dfc095b983a77202312a4ce77cc7f9a7b0355b22\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"integrity\": \"sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==\", \"time\": 0, \"size\": 3210, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0913a74f5e223a4fe6108493dd3b03c2d47259df459926160659513c9ad3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/f4"
+    },
+    {
+        "type": "inline",
+        "contents": "dfe3604ba97ffbf8d9f824c19e609c104af1aa50\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz\", \"integrity\": \"sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==\", \"time\": 0, \"size\": 20356, \"metadata\": {\"url\": \"https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c620bd1b17ab2b1120295c814b3ae5720404751f57360916f6d71e125f89",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/7e"
     },
     {
         "type": "inline",
@@ -1445,27 +4834,33 @@
     },
     {
         "type": "inline",
-        "contents": "e154e397b2c56df82e606250af46c4a1569de96a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz\", \"integrity\": \"sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==\", \"time\": 0, \"size\": 4622505, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "0873d42e5ca6f2c0f375825c487b1443981efb63483da5d3ad65e4a543d2",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/fe"
+        "contents": "e3b502f470b2d76f1070b0c80395c46a9d6c6114\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.26.tgz\", \"integrity\": \"sha512-hH0SMitMxnB43OZpyF1IFPS9bgb2I3bpCh76m2WEK7BE0A0EzpYsRp0CCH2xNKshr7kacU5TQBLYn4zj7CG60A==\", \"time\": 0, \"size\": 7459, \"metadata\": {\"url\": \"https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.26.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "12c5cb64fbec7090237a78ccae965c7d19f75f574ea2b9d73c0954d73642",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/95"
     },
     {
         "type": "inline",
-        "contents": "e2a0bd9637d4ffaed29677d59a8853f66ea517cc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz\", \"integrity\": \"sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==\", \"time\": 0, \"size\": 4171337, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "29b5ff0669860807dfffcda1b15e66becf3afeb8c7def08e70d0e3bc5c22",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/de"
+        "contents": "e3d209deb4977c678c000d2ccc4432d949948b6e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz\", \"integrity\": \"sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==\", \"time\": 0, \"size\": 2847, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4b439cd530e6a38af802bae49d3069b7907c9a582ea8e49f5b4f5c2fa497",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/6e"
     },
     {
         "type": "inline",
-        "contents": "e4d91588a8e8864b4f7c09aa132a6908e9c2bf9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.23.tgz\", \"integrity\": \"sha512-Z1Uc8IB57Lm6k7q6KIDu/p+JWtf3xsXJqAX/5r18hYOTpJyBn0KXUR8oTJ4WFYOcDzWC9n3IflGgHowx6U6z9Q==\", \"time\": 0, \"size\": 4276, \"metadata\": {\"url\": \"https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.23.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2a7b7d30fbf0672362ae42eac52e117cd5ff2f7d48f1663afa6d989ac430",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/41"
+        "contents": "e57ba0945831893a484ebfe58bb8dca45edf3862\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz\", \"integrity\": \"sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==\", \"time\": 0, \"size\": 2014, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "776e802f1724c4c8112320bcc38faa720e5a6d0ab175d77d56292da8b666",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/25"
     },
     {
         "type": "inline",
-        "contents": "e62b0381cc8e5c2bc0bf69ed0f57f6c7bdd2f9d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz\", \"integrity\": \"sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==\", \"time\": 0, \"size\": 7454, \"metadata\": {\"url\": \"https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "2c5a1adf3fb733cd8570777c106e710c375fb00422f49d51093817a45345",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/a2"
+        "contents": "e5c8d688b6f4deb438d53af0e0f8186131929506\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz\", \"integrity\": \"sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==\", \"time\": 0, \"size\": 2246, \"metadata\": {\"url\": \"https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8e7e8934679b7b49b8240b1f2dcb66c25a5bd17f9629f8fe0ea634cab93c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/6f"
+    },
+    {
+        "type": "inline",
+        "contents": "e679f91fe24a8589a1ac6e1e50b9d121cb19d684\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz\", \"integrity\": \"sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==\", \"time\": 0, \"size\": 2233, \"metadata\": {\"url\": \"https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "87253508181b576c3a8c9c6b98d40923ec75acf1d7acef4ecea543096037",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/d0"
     },
     {
         "type": "inline",
@@ -1475,21 +4870,63 @@
     },
     {
         "type": "inline",
+        "contents": "e7f70b6daaa6d5f2f6f2da2eae236d97646cf38e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.8.tgz\", \"integrity\": \"sha512-PfwAW7BLopqaJbneChNL6cUOTL3GL+0l8paYP5shhgY5toBNidWnMXWM+qDwL7MC9+zDtzCF2enT8r6VPu64iw==\", \"time\": 0, \"size\": 77018, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6def8014b0e9bf201b394b14b1971ee8551fff8eaace9e10d0d6cc0908d0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/45/ff"
+    },
+    {
+        "type": "inline",
+        "contents": "e9294a9aba7671f070276400c470a2d2ccc8841f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz\", \"integrity\": \"sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==\", \"time\": 0, \"size\": 9327, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c7775a9f3a40b6506628d5faa222f01d9ce23d50cbad79199b4756ab941f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/61/84"
+    },
+    {
+        "type": "inline",
+        "contents": "ea725d888e6511f5a904e56b59e7f2c329f13128\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz\", \"integrity\": \"sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==\", \"time\": 0, \"size\": 9611, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c31fe581fe1ddf98eb01a47fe86074df4465cd14682af4f02041df108c6f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/55/7f"
+    },
+    {
+        "type": "inline",
         "contents": "ea8b351ed3024a2f9bd3694b0f5e43444410d1d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz\", \"integrity\": \"sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==\", \"time\": 0, \"size\": 65407, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
         "dest-filename": "d1da7d8bd9802bb8afce9927894da9f08f864ea6e7b87a3c5ba748cb82ea",
         "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/24"
     },
     {
         "type": "inline",
-        "contents": "ec2e92b8fdba45b762497129ce7babfc3875e1ea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.5.tgz\", \"integrity\": \"sha512-FMcqyzWN+sYBeqRMWPGT2QY0mUasZMVIuHvmb5NT3eeqPrbHBYtCP8JWEUCDCgM+Zr62uuWY/qoeBrPrzfa78w==\", \"time\": 0, \"size\": 70629, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "124764278b184e3396fb0699d38e95fce1c446c5e092afe63de25e8ca89e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/4a"
+        "contents": "eaa4f18028cd01864fbaf3e8c54ca99b0ed13d38\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz\", \"integrity\": \"sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==\", \"time\": 0, \"size\": 4286, \"metadata\": {\"url\": \"https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "777acfe3c0b839dd2cb2842db398827a55b1a12120ab172593ca0b826b24",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/19/d5"
     },
     {
         "type": "inline",
-        "contents": "ed19dd6a9d01220a3bfb494328d3d3e5795a056f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz\", \"integrity\": \"sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==\", \"time\": 0, \"size\": 4180622, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "7e9d3b4c09d59f837451846cd59f0276f2b52a47035eedc23e2cb37e31ae",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/e5"
+        "contents": "eb34bfeb934cc2557a7c91147a2584694f1fbdf7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz\", \"integrity\": \"sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==\", \"time\": 0, \"size\": 6696, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "125b1897329f1d491d8ba232347d3cc01373d3652cf0556fa2ba067f9226",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/a5"
+    },
+    {
+        "type": "inline",
+        "contents": "eb8eeeff63dad7a5fdee838a984c4a5441e9f693\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-antfu/-/eslint-plugin-antfu-3.1.1.tgz\", \"integrity\": \"sha512-7Q+NhwLfHJFvopI2HBZbSxWXngTwBLKxW1AGXLr2lEGxcEIK/AsDs8pn8fvIizl5aZjBbVbVK5ujmMpBe4Tvdg==\", \"time\": 0, \"size\": 8098, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-antfu/-/eslint-plugin-antfu-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "78a9516198252dd43161af2697cd36c14c432bc84ee6d209e1cb7ef24e90",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/d8"
+    },
+    {
+        "type": "inline",
+        "contents": "ec302c3cc485179b7be670e3bd9a12af31d52b63\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz\", \"integrity\": \"sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==\", \"time\": 0, \"size\": 4551, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e26aee52b62f320a0013bebcfc0561039847535143219ec75699877de4f7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/1d"
+    },
+    {
+        "type": "inline",
+        "contents": "ee2d9197d9a3ad5ab518a95e4d3d6f7c95f5ac46\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz\", \"integrity\": \"sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==\", \"time\": 0, \"size\": 4173032, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8c9b511ade75bbb78de5977efe952b3a611dd1b740e7f6e1ce4e6aa6191e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/cf"
+    },
+    {
+        "type": "inline",
+        "contents": "ee3f0db4c476ccac15546071989f2aae3ad3a4e2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz\", \"integrity\": \"sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==\", \"time\": 0, \"size\": 2225, \"metadata\": {\"url\": \"https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d7156880ad5c5d031b02bd4e7f7c2a6d0c0655146a4df5647682be15a6ba",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/e1"
     },
     {
         "type": "inline",
@@ -1499,9 +4936,57 @@
     },
     {
         "type": "inline",
-        "contents": "f0ce95cf1fe8292ed08e3664910e9f332c3d559a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.52.tgz\", \"integrity\": \"sha512-tzpnRQXJrSzb8Z9sm97UD3cY0toKOImx+xRKsDLX4zHaAlRXWh7jbaKBePJXEN7gNw7Nm03PBNwphdtA8KSUYQ==\", \"time\": 0, \"size\": 8648849, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.52.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "3c98f35c10be1b189a657fc0d0b6ecbc155a00cc9bed79a8ca438bfa2cab",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/d6"
+        "contents": "ef101fa3d1b914a74cab8c85d63ce4177dbc4a9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz\", \"integrity\": \"sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==\", \"time\": 0, \"size\": 4562, \"metadata\": {\"url\": \"https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "49162e5e91a04e2cf4886cf6a21a59d710bb155f72367fc3ef845addb460",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b1/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "ef9e602146e14145af7918b2d47487b6312921e9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz\", \"integrity\": \"sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==\", \"time\": 0, \"size\": 30023, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "86e844b90998bc2fde97c185d57a7e407ed9baf8a225280f4941a14fdc80",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9e/50"
+    },
+    {
+        "type": "inline",
+        "contents": "f07ac881addb502eb3c5c408ff508ed38a85d2cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-a1y5fiB0iovuzdbjUxa7+Zcvgv+mTmlGGC4XydVIsyl48eoxgaYkA3l9079hyTyhECsPq+mbr0gVQsFU11OJAQ==\", \"time\": 0, \"size\": 7939978, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "eb2bfbcf9a6af38bf2852eed74bbf7588eb23391869c4df6979957d511a0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/be"
+    },
+    {
+        "type": "inline",
+        "contents": "f0adc5842f8c0a07be3f927a6df0070c6dc9fe85\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz\", \"integrity\": \"sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==\", \"time\": 0, \"size\": 8052, \"metadata\": {\"url\": \"https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1dc46fbb60fdd4bf8b84dc091030bd86c7d42fd5d9cf9bb6bc7a6d2a8ce0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/62"
+    },
+    {
+        "type": "inline",
+        "contents": "f0c6bdbea0a8e99d93a40bde95916b4cc895540f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz\", \"integrity\": \"sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==\", \"time\": 0, \"size\": 12037, \"metadata\": {\"url\": \"https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "963818a10ad4bcbb771d18f4a0df2274361d894f04f1f0d499f69e1da6bf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/13"
+    },
+    {
+        "type": "inline",
+        "contents": "f14994d62b6153c334f3eb58465c90a313e54226\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz\", \"integrity\": \"sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==\", \"time\": 0, \"size\": 3699, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f18a9a75bf7bd16cdb1b75eaccaa4ced854717a581a33918e15c61fc4ac5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/e6"
+    },
+    {
+        "type": "inline",
+        "contents": "f1a2e902f1ee495fced360b74011384e69bd8bf4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz\", \"integrity\": \"sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==\", \"time\": 0, \"size\": 58380, \"metadata\": {\"url\": \"https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9629da9a7be63960027f78f1148b6bf3ebf5ab4fa35a316df2242ded571a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/6e"
+    },
+    {
+        "type": "inline",
+        "contents": "f2d6ab78983ae31107e08b2d86294523c534b84c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.76.0.tgz\", \"integrity\": \"sha512-g+RihtzFgGTx2WYCuTHbdOXJeAlGnROws0TeALx9ow/ZmOROOZkVg5wp/B44n0WJgI4SQFP1eWM2iRPlU2Y14w==\", \"time\": 0, \"size\": 34247, \"metadata\": {\"url\": \"https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.76.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "da26f37b775989c1f6d8e67e746b2313c6412b1bf5fa2f10c8f1cc1a1b9e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/2c"
+    },
+    {
+        "type": "inline",
+        "contents": "f4d0c8c417efa70f1d3be21c9a8018815480f0bc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-config-flat-gitignore/-/eslint-config-flat-gitignore-2.1.0.tgz\", \"integrity\": \"sha512-cJzNJ7L+psWp5mXM7jBX+fjHtBvvh06RBlcweMhKD8jWqQw0G78hOW5tpVALGHGFPsBV+ot2H+pdDGJy6CV8pA==\", \"time\": 0, \"size\": 4318, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-config-flat-gitignore/-/eslint-config-flat-gitignore-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6bbbe7ff53409c5cc117d5ec0e9429524edaa676b3057a48d4a6df140625",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/ea"
     },
     {
         "type": "inline",
@@ -1511,9 +4996,99 @@
     },
     {
         "type": "inline",
-        "contents": "f6e5ac8965e83d8142f38bcb593d569956afd52b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz\", \"integrity\": \"sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==\", \"time\": 0, \"size\": 4645866, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
-        "dest-filename": "77efbaa042b66cd079c702aea652f4ac31186e9125aef90d9d2adb0a4c8e",
-        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/79"
+        "contents": "f570bb86e1b44057d8807cbaaa957031131951bf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz\", \"integrity\": \"sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==\", \"time\": 0, \"size\": 4409, \"metadata\": {\"url\": \"https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7551d241cb30c6b780bfac91fe638ab4ee94cbbb639305be492e439c37b0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/72/6f"
+    },
+    {
+        "type": "inline",
+        "contents": "f5f43fbca76fb561b23a43b330d056dd5380aed4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz\", \"integrity\": \"sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==\", \"time\": 0, \"size\": 2645, \"metadata\": {\"url\": \"https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b2b965f3c5ed08135b1377162e60d4bfeed2ff0e83aa025d4fcdfe405292",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4d/aa"
+    },
+    {
+        "type": "inline",
+        "contents": "f609600fb6b72f62f245098772a7c70e38fd0c08\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz\", \"integrity\": \"sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==\", \"time\": 0, \"size\": 4415859, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "95a8d2a88014a020317302e3facee319d01b6336b5d468400f8e8befa2c2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/04/4b"
+    },
+    {
+        "type": "inline",
+        "contents": "f62c18923f18aeb6ff861b81464461e858a520aa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.53.tgz\", \"integrity\": \"sha512-yIsKqMz0CtRnVa6x3Pa+mzTihr4Ty+Z6HfPbZ7RVbk1Uxnco4+CUn7Qbm/5SBol1JD/7nvY8rphAgyAi7Lj6Vg==\", \"time\": 0, \"size\": 7798867, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.53.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a349d5f97e80a5c03d3e32d4857ad384fea92ac418f597a3f13806295c4d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/89"
+    },
+    {
+        "type": "inline",
+        "contents": "f7049f1daea45602151f8d782e7ff5edda778002\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz\", \"integrity\": \"sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==\", \"time\": 0, \"size\": 31505, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1cced0cfdb0304e9fe137fabc72fa87b8c163ec5a0dc10d3e9b8baadf71f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/6b"
+    },
+    {
+        "type": "inline",
+        "contents": "f73b6772b90ba45e3e4f793c9cf8b1829aac93cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@oxc-project/types/-/types-0.101.0.tgz\", \"integrity\": \"sha512-nuFhqlUzJX+gVIPPfuE6xurd4lST3mdcWOhyK/rZO0B9XWMKm79SuszIQEnSMmmDhq1DC8WWVYGVd+6F93o1gQ==\", \"time\": 0, \"size\": 7741, \"metadata\": {\"url\": \"https://registry.npmjs.org/@oxc-project/types/-/types-0.101.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a7231369f9593b243a24b0f76aef8936d5cff9953af1d89a3effc50ffa2c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/ce"
+    },
+    {
+        "type": "inline",
+        "contents": "f7e064e628f505b02167bcf0fad27748ac58086b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz\", \"integrity\": \"sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==\", \"time\": 0, \"size\": 7487, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b626576890e19545b251c2108efb0efb53e874533962804e74732dc34ecb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/a9"
+    },
+    {
+        "type": "inline",
+        "contents": "fa0f3e9362602cf50db5b6db7d10c92e610a0c42\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz\", \"integrity\": \"sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==\", \"time\": 0, \"size\": 3788, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c796bb06e1f0fdb34f77644d3e07532bdea8e62b0e32db9d1ce3f7bb3d03",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f1/3c"
+    },
+    {
+        "type": "inline",
+        "contents": "facaa058dfabe3de95d3df73588b3d7983ddcfea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.23.1.tgz\", \"integrity\": \"sha512-68PealUpYoHOBh332JLLD9Sj7OQUDkFpmcfqt8R9sySfFSeuGJjMTJQvCRRB96zO3A/PELRLkPrzsHmzEFQQ5A==\", \"time\": 0, \"size\": 89892, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.23.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2a3fd45223a38ac6d4ba3a09424e4e81f433b6a6376b2170cb768f8e7e0f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/41"
+    },
+    {
+        "type": "inline",
+        "contents": "facbec5a1fbe6f2c19a69c445da7a927f452aa89\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz\", \"integrity\": \"sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==\", \"time\": 0, \"size\": 4351, \"metadata\": {\"url\": \"https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "21ec51f747cb21049d75e172d90815983a7e0773bcc7454de82e32497509",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/3d"
+    },
+    {
+        "type": "inline",
+        "contents": "fafceda046396e23a6fb85de04b199ff5d1df24d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz\", \"integrity\": \"sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==\", \"time\": 0, \"size\": 4513, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fcc8757308e226694e9489b211dc2069cfddc4e18099d3839ad3b0f0f513",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/92"
+    },
+    {
+        "type": "inline",
+        "contents": "fb1be7f69d4ecf636c0348cbebd02d75a02b5d24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz\", \"integrity\": \"sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==\", \"time\": 0, \"size\": 2765, \"metadata\": {\"url\": \"https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2ace9a1dfbea06eafdda3044e21e830e5cbd76a5eb5a794acdc111e0c31e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cb/f4"
+    },
+    {
+        "type": "inline",
+        "contents": "fb362520678b6d804bddda6eef3a24e9fdefd901\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz\", \"integrity\": \"sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==\", \"time\": 0, \"size\": 4728, \"metadata\": {\"url\": \"https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "12cfd4f6ff2ec7cde766b3d18b90f02b51984ae1f7cf5d7111c96f1dc41c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/36"
+    },
+    {
+        "type": "inline",
+        "contents": "fc94972138986dc3ae72a575375c1751b59732f8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.5.0.tgz\", \"integrity\": \"sha512-PR81eOGq4S7diVnV9xzFSBE4CDENRQGP0Lckkek8AdHtbj+6Bm0cItwlFnxsLFriJHspiE3mpu8U20eODyToIg==\", \"time\": 0, \"size\": 707459, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fcb4c7e1ad7d811d0b2a3499dbe61595bf1c85dfecbed49c7c2369c1a657",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/43/ff"
+    },
+    {
+        "type": "inline",
+        "contents": "fcd35da05f9c87a2f7725b0457d2f4579eec1bf2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz\", \"integrity\": \"sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==\", \"time\": 0, \"size\": 11106, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c8d4583d3ccd74993cd4f903c6c061c4ce30fbfede60b4bb8856e13cfae9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/f8"
+    },
+    {
+        "type": "inline",
+        "contents": "fd54922d7267a4e2a335f4faa666e3a88bf25bae\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz\", \"integrity\": \"sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==\", \"time\": 0, \"size\": 3806, \"metadata\": {\"url\": \"https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a2590d81727a5f907971aec316d449516a7f62bdc4422e85ce5dbe1cc3ce",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/0c"
     },
     {
         "type": "inline",
@@ -1543,8 +5118,8 @@
         "type": "shell",
         "commands": [
             "mkdir -p \"bin/@esbuild\"",
-            "cp \".package/@esbuild/linux-arm64@0.27.0/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.27.0\"",
-            "ln -sf \"linux-arm64@0.27.0\" \"bin/esbuild-current\""
+            "cp \".package/@esbuild/linux-arm64@0.27.1/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.27.1\"",
+            "ln -sf \"linux-arm64@0.27.1\" \"bin/esbuild-current\""
         ],
         "dest": "flatpak-node/cache/esbuild",
         "only-arches": [
@@ -1555,8 +5130,8 @@
         "type": "shell",
         "commands": [
             "mkdir -p \"bin/@esbuild\"",
-            "cp \".package/@esbuild/linux-arm@0.27.0/bin/esbuild\" \"bin/@esbuild/linux-arm@0.27.0\"",
-            "ln -sf \"linux-arm@0.27.0\" \"bin/esbuild-current\""
+            "cp \".package/@esbuild/linux-arm@0.27.1/bin/esbuild\" \"bin/@esbuild/linux-arm@0.27.1\"",
+            "ln -sf \"linux-arm@0.27.1\" \"bin/esbuild-current\""
         ],
         "dest": "flatpak-node/cache/esbuild",
         "only-arches": [
@@ -1567,8 +5142,8 @@
         "type": "shell",
         "commands": [
             "mkdir -p \"bin/@esbuild\"",
-            "cp \".package/@esbuild/linux-ia32@0.27.0/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.27.0\"",
-            "ln -sf \"linux-ia32@0.27.0\" \"bin/esbuild-current\""
+            "cp \".package/@esbuild/linux-ia32@0.27.1/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.27.1\"",
+            "ln -sf \"linux-ia32@0.27.1\" \"bin/esbuild-current\""
         ],
         "dest": "flatpak-node/cache/esbuild",
         "only-arches": [
@@ -1579,8 +5154,8 @@
         "type": "shell",
         "commands": [
             "mkdir -p \"bin/@esbuild\"",
-            "cp \".package/@esbuild/linux-x64@0.27.0/bin/esbuild\" \"bin/@esbuild/linux-x64@0.27.0\"",
-            "ln -sf \"linux-x64@0.27.0\" \"bin/esbuild-current\""
+            "cp \".package/@esbuild/linux-x64@0.27.1/bin/esbuild\" \"bin/@esbuild/linux-x64@0.27.1\"",
+            "ln -sf \"linux-x64@0.27.1\" \"bin/esbuild-current\""
         ],
         "dest": "flatpak-node/cache/esbuild",
         "only-arches": [


### PR DESCRIPTION
Update Whis to version 0.6.0

## Changes
- Update git source to v0.6.0 (commit 5d1fd2f)
- Update screenshot URLs with new commit SHA
- Add v0.6.0 release notes to metainfo.xml
- Regenerate cargo-sources.json and node-sources.json
- Add build optimizations: SIMD flags, WHISPER_DONT_GENERATE_BINDINGS
- Track desktop file and metainfo.xml
- Add .gitignore for build artifacts
- Fix XML parsing error (escaped ampersand)
- Clean up unused dependencies from cargo-sources.json

## Testing
- Successfully built with flatpak-builder
- Validated metainfo.xml with appstreamcli
- All 16 artifacts present